### PR TITLE
Use mir for initialization and mutation provide script support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-intent",
  "aptos-logger",
  "aptos-openapi",
  "aptos-resource-viewer",
@@ -687,6 +688,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-dynamic-transaction-composer"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "getrandom 0.2.16",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "serde",
+ "serde_bytes",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
 dependencies = [
@@ -890,6 +907,7 @@ dependencies = [
  "aptos-config",
  "aptos-crypto",
  "aptos-db",
+ "aptos-dynamic-transaction-composer",
  "aptos-executor",
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1062,6 +1080,27 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
+
+[[package]]
+name = "aptos-intent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "bytes",
+ "getrandom 0.2.16",
+ "hex",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "reqwest",
+ "reqwest-wasm",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
 
 [[package]]
 name = "aptos-jellyfish-merkle"
@@ -4471,8 +4510,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8325,7 +8366,45 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest-wasm"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fdca8934fccbd5aec3e208bdb5a76107ce8690aa51c6c292c31f21541b52b9"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "encoding_rs",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -11366,6 +11445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "bcs 0.1.6",
  "bytes",
  "dashmap 6.1.0",
+ "hex",
  "libafl",
  "libafl_bolts",
  "move-binary-format",
@@ -911,6 +912,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "serde",
+ "serde_json",
  "serde_yaml 0.9.34+deprecated",
 ]
 

--- a/bin/libafl-aptos/src/main.rs
+++ b/bin/libafl-aptos/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
     #[arg(long = "module-path", value_name = "MODULE_PATH")]
     module_path: Option<PathBuf>,
 
+    /// Path to a MIR JSON file to initialize corpus
+    #[arg(long = "mir-path", value_name = "MIR_PATH")]
+    mir_path: Option<PathBuf>,
+
     /// Timeout in seconds (0 = no timeout, run indefinitely)
     #[arg(long = "timeout", short = 't', default_value = "0")]
     timeout_seconds: u64,
@@ -57,15 +61,25 @@ fn main() {
     let mut mgr = SimpleEventManager::new(mon);
     let scheduler = QueueScheduler::new();
 
-    let abi = cli
-        .abi_path
-        .clone()
-        .unwrap_or_else(|| panic!("--abi-path is required (no fallback)."));
-    let module = cli
-        .module_path
-        .clone()
-        .unwrap_or_else(|| panic!("--module-path is required (no fallback)."));
-    let mut state = AptosFuzzerState::new(Some(abi), Some(module));
+    // Initialize state either from MIR file or from ABI
+    let mut state = if let Some(mir_path) = cli.mir_path.clone() {
+        let module = cli
+            .module_path
+            .clone()
+            .unwrap_or_else(|| panic!("--module-path is required when using --mir-path."));
+        AptosFuzzerState::load_from_mir(Some(mir_path), Some(module))
+    } else {
+        let abi = cli
+            .abi_path
+            .clone()
+            .unwrap_or_else(|| panic!("--abi-path is required (no fallback)."));
+        let module = cli
+            .module_path
+            .clone()
+            .unwrap_or_else(|| panic!("--module-path is required (no fallback)."));
+        AptosFuzzerState::new(Some(abi), Some(module))
+    };
+    
     let _ = feedback.init_state(&mut state);
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 

--- a/bin/libafl-aptos/src/main.rs
+++ b/bin/libafl-aptos/src/main.rs
@@ -25,17 +25,13 @@ use utils::print_fuzzer_stats;
 #[derive(Debug, Parser)]
 #[command(author, version, about = "LibAFL-based fuzzer for Aptos Move modules")]
 struct Cli {
-    /// Path to an ABI file or directory to seed initial inputs
-    #[arg(long = "abi-path", value_name = "ABI_PATH")]
-    abi_path: Option<PathBuf>,
-
     /// Path to a compiled Move module to publish before fuzzing
     #[arg(long = "module-path", value_name = "MODULE_PATH")]
-    module_path: Option<PathBuf>,
+    module_path: PathBuf,
 
     /// Path to a MIR JSON file to initialize corpus
     #[arg(long = "mir-path", value_name = "MIR_PATH")]
-    mir_path: Option<PathBuf>,
+    mir_path: PathBuf,
 
     /// Timeout in seconds (0 = no timeout, run indefinitely)
     #[arg(long = "timeout", short = 't', default_value = "0")]
@@ -61,24 +57,8 @@ fn main() {
     let mut mgr = SimpleEventManager::new(mon);
     let scheduler = QueueScheduler::new();
 
-    // Initialize state either from MIR file or from ABI
-    let mut state = if let Some(mir_path) = cli.mir_path.clone() {
-        let module = cli
-            .module_path
-            .clone()
-            .unwrap_or_else(|| panic!("--module-path is required when using --mir-path."));
-        AptosFuzzerState::load_from_mir(Some(mir_path), Some(module))
-    } else {
-        let abi = cli
-            .abi_path
-            .clone()
-            .unwrap_or_else(|| panic!("--abi-path is required (no fallback)."));
-        let module = cli
-            .module_path
-            .clone()
-            .unwrap_or_else(|| panic!("--module-path is required (no fallback)."));
-        AptosFuzzerState::new(Some(abi), Some(module))
-    };
+    // Initialize state from MIR file
+    let mut state = AptosFuzzerState::load_from_mir(Some(cli.mir_path.clone()), Some(cli.module_path.clone()));
     
     let _ = feedback.init_state(&mut state);
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/bin/libafl-aptos/src/main.rs
+++ b/bin/libafl-aptos/src/main.rs
@@ -151,9 +151,10 @@ fn main() {
     //     println!("Discovered solutions:");
     //     for input in solutions {
     //         println!("  {:?}", input);
-    //         if let Some(execution_path) = state.get_solution_execution_path(&input) {
-    //             println!("    Execution path: {:?}", execution_path);
-    //             if let Some(path_id) = state.get_solution_execution_path_id(&input) {
+    //         if let Some(execution_path) =
+    // state.get_solution_execution_path(&input) {             println!("
+    // Execution path: {:?}", execution_path);             if let
+    // Some(path_id) = state.get_solution_execution_path_id(&input) {
     //                 if state.abort_code_paths.contains(&path_id) {
     //                     println!("    Found InvariantViolation!");
     //                 }

--- a/bin/libafl-aptos/src/main.rs
+++ b/bin/libafl-aptos/src/main.rs
@@ -146,22 +146,22 @@ fn main() {
         total_instructions_executed,
         total_possible_edges,
     );
-    let solutions = state.take_solutions();
-    if !solutions.is_empty() {
-        println!("Discovered solutions:");
-        for input in solutions {
-            println!("  {:?}", input);
-            if let Some(execution_path) = state.get_solution_execution_path(&input) {
-                println!("    Execution path: {:?}", execution_path);
-                if let Some(path_id) = state.get_solution_execution_path_id(&input) {
-                    if state.abort_code_paths.contains(&path_id) {
-                        println!("    Found InvariantViolation!");
-                    }
-                    if state.shift_overflow_paths.contains(&path_id) {
-                        println!("    Found ShiftOverflow!");
-                    }
-                }
-            }
-        }
-    }
+    // let solutions = state.take_solutions();
+    // if !solutions.is_empty() {
+    //     println!("Discovered solutions:");
+    //     for input in solutions {
+    //         println!("  {:?}", input);
+    //         if let Some(execution_path) = state.get_solution_execution_path(&input) {
+    //             println!("    Execution path: {:?}", execution_path);
+    //             if let Some(path_id) = state.get_solution_execution_path_id(&input) {
+    //                 if state.abort_code_paths.contains(&path_id) {
+    //                     println!("    Found InvariantViolation!");
+    //                 }
+    //                 if state.shift_overflow_paths.contains(&path_id) {
+    //                     println!("    Found ShiftOverflow!");
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/bin/libafl-aptos/src/main.rs
+++ b/bin/libafl-aptos/src/main.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aptos_fuzzer::{
-    AbortCodeObjective, AptosFuzzerMutator, AptosFuzzerState, AptosMoveExecutor,
-    ShiftOverflowObjective,
+    AbortCodeObjective, AptosFuzzerMutator, AptosFuzzerState, AptosMoveExecutor, ShiftOverflowObjective,
 };
 use clap::Parser;
 use libafl::corpus::Corpus;
@@ -59,7 +58,7 @@ fn main() {
 
     // Initialize state from MIR file
     let mut state = AptosFuzzerState::load_from_mir(Some(cli.mir_path.clone()), Some(cli.module_path.clone()));
-    
+
     let _ = feedback.init_state(&mut state);
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 

--- a/contracts/fuzzing-demo/mir.json
+++ b/contracts/fuzzing-demo/mir.json
@@ -1,0 +1,943 @@
+{
+    "calls": [
+      {
+        "id": 0,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "branching_arithmetic",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 3,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 1,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "check_invariants",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 2,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "check_overflow_conditions",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 3,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "dangerous_division",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 4,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "dangerous_multiplication",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 5,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "explore_path",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U8"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          },
+          {
+            "Var": {
+              "id": 3,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [
+          "@MultiPathState"
+        ],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@MultiPathState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 6,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "init_arithmetic_state",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@ArithmeticState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [
+          {
+            "Creates": {
+              "struct_name": "@ArithmeticState",
+              "addr": {
+                "Literal": "unknown"
+              }
+            }
+          }
+        ],
+        "ret": null
+      },
+      {
+        "id": 7,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "init_multi_path",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@MultiPathState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [
+          {
+            "Creates": {
+              "struct_name": "@MultiPathState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "ret": null
+      },
+      {
+        "id": 8,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "init_nested_state",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 3,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 4,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@NestedState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [
+          {
+            "Creates": {
+              "struct_name": "@NestedState",
+              "addr": {
+                "Literal": "unknown"
+              }
+            }
+          }
+        ],
+        "ret": null
+      },
+      {
+        "id": 9,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "init_state_machine",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@StateMachine",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [
+          {
+            "Creates": {
+              "struct_name": "@StateMachine",
+              "addr": {
+                "Literal": "unknown"
+              }
+            }
+          }
+        ],
+        "ret": null
+      },
+      {
+        "id": 10,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "magic_number_hunter",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 11,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "nested_assertions",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 3,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 12,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "nested_conditional_arithmetic",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 3,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 4,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 13,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "nested_state_operation",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [
+          "@NestedState"
+        ],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@NestedState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 14,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "range_based_branches",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 15,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "state_transition",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          }
+        ],
+        "acquires": [
+          "@StateMachine"
+        ],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@StateMachine",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 16,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "stateful_arithmetic",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "U64"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [
+          "@ArithmeticState"
+        ],
+        "requires": [
+          {
+            "Exists": {
+              "struct_name": "@ArithmeticState",
+              "addr": {
+                "Var": {
+                  "id": 0,
+                  "ty": "Signer"
+                }
+              }
+            }
+          }
+        ],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 17,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "test_shift_overflow_check",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": "Address"
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      },
+      {
+        "id": 18,
+        "module_addr": "0000000000000000000000000000000000000000000000000000000000000042",
+        "module": "complex_fuzzing",
+        "function": "vector_operations",
+        "ty_args": [],
+        "args": [
+          {
+            "Var": {
+              "id": 0,
+              "ty": "Signer"
+            }
+          },
+          {
+            "Var": {
+              "id": 1,
+              "ty": {
+                "Vector": "U64"
+              }
+            }
+          },
+          {
+            "Var": {
+              "id": 2,
+              "ty": "U8"
+            }
+          }
+        ],
+        "acquires": [],
+        "requires": [],
+        "effects": [],
+        "ret": null
+      }
+    ],
+    "struct_defs": {
+      "@ArithmeticEvent": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "ArithmeticEvent",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "operation",
+            "ty": "U8"
+          },
+          {
+            "name": "value1",
+            "ty": "U64"
+          },
+          {
+            "name": "value2",
+            "ty": "U64"
+          },
+          {
+            "name": "result",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@ArithmeticState": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "ArithmeticState",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "accumulator",
+            "ty": "U64"
+          },
+          {
+            "name": "multiplier",
+            "ty": "U8"
+          },
+          {
+            "name": "operation_count",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@ComplexConfig": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "ComplexConfig",
+          "ty_args": []
+        },
+        "fields": []
+      },
+      "@MultiPathState": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "MultiPathState",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "path_taken",
+            "ty": {
+              "Vector": "U8"
+            }
+          },
+          {
+            "name": "depth",
+            "ty": "U8"
+          },
+          {
+            "name": "score",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@NestedState": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "NestedState",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "value",
+            "ty": "U64"
+          },
+          {
+            "name": "config",
+            "ty": {
+              "Struct": {
+                "address": "0000000000000000000000000000000000000000000000000000000000000042",
+                "module": "complex_fuzzing",
+                "name": "ComplexConfig",
+                "ty_args": []
+              }
+            }
+          },
+          {
+            "name": "flags",
+            "ty": {
+              "Vector": "U8"
+            }
+          }
+        ]
+      },
+      "@OverflowDetectedEvent": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "OverflowDetectedEvent",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "operation_type",
+            "ty": "U8"
+          },
+          {
+            "name": "value",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@PathDiscoveryEvent": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "PathDiscoveryEvent",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "path_id",
+            "ty": "U8"
+          },
+          {
+            "name": "depth",
+            "ty": "U8"
+          },
+          {
+            "name": "value",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@StateChangeEvent": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "StateChangeEvent",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "old_state",
+            "ty": "U8"
+          },
+          {
+            "name": "new_state",
+            "ty": "U8"
+          },
+          {
+            "name": "trigger_value",
+            "ty": "U64"
+          }
+        ]
+      },
+      "@StateMachine": {
+        "tag": {
+          "address": "0000000000000000000000000000000000000000000000000000000000000042",
+          "module": "complex_fuzzing",
+          "name": "StateMachine",
+          "ty_args": []
+        },
+        "fields": [
+          {
+            "name": "current_state",
+            "ty": "U8"
+          },
+          {
+            "name": "transition_count",
+            "ty": "U64"
+          },
+          {
+            "name": "data",
+            "ty": "U64"
+          }
+        ]
+      }
+    },
+    "metadata": {}
+  }

--- a/crates/aptos-fuzzer/Cargo.toml
+++ b/crates/aptos-fuzzer/Cargo.toml
@@ -29,7 +29,9 @@ bytes = { workspace = true }
 libafl = { workspace = true }
 libafl_bolts = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9"
 bcs = { workspace = true }
+hex = { workspace = true }
 dashmap = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/aptos-fuzzer/Cargo.toml
+++ b/crates/aptos-fuzzer/Cargo.toml
@@ -26,6 +26,9 @@ aptos-gas-schedule = { workspace = true }
 aptos-cached-packages = { path = "../../external/aptos-core/aptos-move/framework/cached-packages" }
 bytes = { workspace = true }
 
+# For generating batched Script payloads from function calls
+aptos-dynamic-transaction-composer = { path = "../../external/aptos-core/aptos-move/script-composer" }
+
 libafl = { workspace = true }
 libafl_bolts = { workspace = true }
 serde = { workspace = true }

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -149,7 +149,8 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
         
         // Execute each call in sequence
         for call in &input.calls {
-            let payload = TransactionPayload::EntryFunction(call.clone());
+            let entry_func = call.to_entry_function();
+            let payload = TransactionPayload::EntryFunction(entry_func);
             let (result, outcome, pcs, shift_losses) =
                 self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
             
@@ -176,23 +177,13 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 }
                 self.prev_loc = 0;
 
-                // Use first call for base ID
-                let base_id: u32 = {
-                    let call = &input.calls[0];
-                    let (module, function, _ty_args, _args) = call.clone().into_inner();
-                    let mut buf = Vec::new();
-                    buf.extend_from_slice(module.address().as_ref());
-                    buf.extend_from_slice(module.name().as_str().as_bytes());
-                    buf.extend_from_slice(function.as_str().as_bytes());
-                    Self::hash32(&buf)
-                };
-
                 self.total_instructions_executed += all_pcs.len() as u64;
 
                 {
                     let cumulative_map = state.cumulative_coverage_mut();
                     for &pc in &all_pcs {
-                        let cur_id = base_id ^ pc;
+                        // PCs are now global in the VM trace; use directly
+                        let cur_id = pc;
                         let idx = ((cur_id ^ self.prev_loc) as usize) & (MAP_SIZE - 1);
                         map[idx] = map[idx].saturating_add(1);
                         cumulative_map[idx] = cumulative_map[idx].max(1);

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -2,14 +2,13 @@ use std::marker::PhantomData;
 
 use aptos_move_core_types::vm_status::{StatusCode, VMStatus};
 use aptos_types::transaction::{ExecutionStatus, TransactionPayload, TransactionStatus};
-use aptos_vm::aptos_vm::ExecOutcomeKind;
+use aptos_vm::aptos_vm::{ExecOutcomeKind, FUZZER_SENDER};
 use aptos_vm::AptosVM;
 use libafl::executors::{Executor, ExitKind, HasObservers};
 use libafl::observers::map::{HitcountsMapObserver, OwnedMapObserver};
 use libafl::state::HasExecutions;
 use libafl_bolts::tuples::RefIndexable;
 use libafl_bolts::AsSliceMut;
-
 use crate::executor::aptos_custom_state::AptosCustomState;
 use crate::executor::custom_state_view::CustomStateView;
 use crate::executor::types::TransactionResult;
@@ -138,8 +137,9 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
         input: &AptosFuzzerInput,
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
+        
         let (result, outcome, pcs, shift_losses) =
-            self.execute_transaction(input.payload().clone(), state.aptos_state(), None);
+            self.execute_transaction(input.payload().clone(), state.aptos_state(), Some(FUZZER_SENDER));
 
         // Update execution counter (required by Executor trait contract)
         *state.executions_mut() += 1;

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -76,7 +76,7 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
     ) -> (
         core::result::Result<TransactionResult, VMStatus>,
         ExecOutcomeKind,
-        Vec<u32>,
+        Vec<u64>,
         Vec<bool>,
     ) {
         match &transaction {
@@ -313,6 +313,7 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
         if input.calls.is_empty() { return Ok(ExitKind::Ok); }
+        // PCs from VM are packed u64 per step: upper 32 bits = function hash, lower 32 bits = local pc (u16 widened)
         let mut all_pcs = Vec::new();
         let mut all_shift_losses = Vec::new();
         let mut final_outcome = ExecOutcomeKind::Ok;
@@ -330,18 +331,27 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 let map = self.observers.0.as_slice_mut();
                 for byte in map.iter_mut() { *byte = 0; }
                 self.prev_loc = 0;
+                // Convert packed u64 to hashed u32 tokens for coverage and path recording
                 self.total_instructions_executed += all_pcs.len() as u64;
+                let mut tokens: Vec<u32> = Vec::with_capacity(all_pcs.len());
                 {
                     let cumulative_map = state.cumulative_coverage_mut();
-                    for &pc in &all_pcs {
-                        let cur_id = pc;
-                        let idx = ((cur_id ^ self.prev_loc) as usize) & (MAP_SIZE - 1);
+                    for &packed in &all_pcs {
+                        let fn_hash = (packed >> 32) as u32;
+                        let pc32 = (packed & 0xFFFF_FFFF) as u32;
+                        // Build 8-byte buffer = fn_hash || pc32 and hash to u32
+                        let mut buf = [0u8; 8];
+                        buf[..4].copy_from_slice(&fn_hash.to_le_bytes());
+                        buf[4..].copy_from_slice(&pc32.to_le_bytes());
+                        let token = Self::hash32(&buf);
+                        tokens.push(token);
+                        let idx = ((token ^ self.prev_loc) as usize) & (MAP_SIZE - 1);
                         map[idx] = map[idx].saturating_add(1);
                         cumulative_map[idx] = cumulative_map[idx].max(1);
-                        self.prev_loc = cur_id >> 1;
+                        self.prev_loc = token >> 1;
                     }
                 }
-                state.set_current_execution_path(all_pcs);
+                state.set_current_execution_path(tokens);
                 let cause_loss = all_shift_losses.into_iter().any(|b| b);
                 self.observers.1 .1 .0.set_cause_loss(cause_loss);
                 if let TransactionStatus::Keep(ExecutionStatus::MoveAbort { location: _, code, .. }) = &result.status {
@@ -355,7 +365,17 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 for byte in map.iter_mut() { *byte = 0; }
                 self.prev_loc = 0;
                 self.observers.1 .1 .0.set_cause_loss(false);
-                state.set_current_execution_path(all_pcs);
+                // On error, still record hashed tokens for current path (may be empty)
+                let mut tokens: Vec<u32> = Vec::with_capacity(all_pcs.len());
+                for &packed in &all_pcs {
+                    let fn_hash = (packed >> 32) as u32;
+                    let pc32 = (packed & 0xFFFF_FFFF) as u32;
+                    let mut buf = [0u8; 8];
+                    buf[..4].copy_from_slice(&fn_hash.to_le_bytes());
+                    buf[4..].copy_from_slice(&pc32.to_le_bytes());
+                    tokens.push(Self::hash32(&buf));
+                }
+                state.set_current_execution_path(tokens);
                 if let VMStatus::MoveAbort(ref _loc, code) = vm_status { self.observers.1 .0.set_last(Some(code)); } else { self.observers.1 .0.set_last(None); }
                 let exit_kind = match final_outcome {
                     ExecOutcomeKind::Ok => ExitKind::Ok,

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -146,14 +146,15 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
 
         // Add each batched call with ty args and arguments
         for call in &input.calls {
-            let module_str = call.module_id.to_string();
+            let module_str = format!(
+                "{}::{}",
+                call.module_id.address().to_standard_string(),
+                call.module_id.name()
+            );
             let function_str = call.function_name.to_string();
             let ty_args: Vec<String> = call.ty_args.iter().map(TypeTag::to_canonical_string).collect();
             let args = call.args.clone();
-            if composer
-                .add_batched_call(module_str, function_str, ty_args, args)
-                .is_err()
-            {
+            if composer.add_batched_call(module_str, function_str, ty_args, args).is_err() {
                 return None;
             }
         }

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -138,13 +138,36 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
         
-        let (result, outcome, pcs, shift_losses) =
-            self.execute_transaction(input.payload().clone(), state.aptos_state(), Some(FUZZER_SENDER));
+        if input.calls.is_empty() {
+            return Ok(ExitKind::Ok);
+        }
+        
+        let mut all_pcs = Vec::new();
+        let mut all_shift_losses = Vec::new();
+        let mut final_outcome = ExecOutcomeKind::Ok;
+        let mut final_result = None;
+        
+        // Execute each call in sequence
+        for call in &input.calls {
+            let payload = TransactionPayload::EntryFunction(call.clone());
+            let (result, outcome, pcs, shift_losses) =
+                self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
+            
+            all_pcs.extend(pcs);
+            all_shift_losses.extend(shift_losses);
+            final_outcome = outcome;
+            final_result = Some(result);
+            
+            // Stop execution on error
+            if final_result.as_ref().unwrap().is_err() {
+                break;
+            }
+        }
 
-        // Update execution counter (required by Executor trait contract)
+        // Update execution counter
         *state.executions_mut() += 1;
 
-        match result {
+        match final_result.unwrap() {
             Ok(result) => {
                 self.success_count += 1;
                 let map = self.observers.0.as_slice_mut();
@@ -153,26 +176,22 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 }
                 self.prev_loc = 0;
 
-                // Build stable per-function base ID
-                let base_id: u32 = match input.payload() {
-                    TransactionPayload::EntryFunction(ef) => {
-                        let (module, function, _ty_args, _args) = ef.clone().into_inner();
-                        let mut buf = Vec::new();
-                        buf.extend_from_slice(module.address().as_ref());
-                        buf.extend_from_slice(module.name().as_str().as_bytes());
-                        buf.extend_from_slice(function.as_str().as_bytes());
-                        Self::hash32(&buf)
-                    }
-                    TransactionPayload::Script(script) => Self::hash32(script.code()),
-                    _ => 0,
+                // Use first call for base ID
+                let base_id: u32 = {
+                    let call = &input.calls[0];
+                    let (module, function, _ty_args, _args) = call.clone().into_inner();
+                    let mut buf = Vec::new();
+                    buf.extend_from_slice(module.address().as_ref());
+                    buf.extend_from_slice(module.name().as_str().as_bytes());
+                    buf.extend_from_slice(function.as_str().as_bytes());
+                    Self::hash32(&buf)
                 };
 
-                self.total_instructions_executed += pcs.len() as u64;
+                self.total_instructions_executed += all_pcs.len() as u64;
 
                 {
                     let cumulative_map = state.cumulative_coverage_mut();
-                    // Update AFL-style edge coverage in observer and cumulative maps
-                    for &pc in &pcs {
+                    for &pc in &all_pcs {
                         let cur_id = base_id ^ pc;
                         let idx = ((cur_id ^ self.prev_loc) as usize) & (MAP_SIZE - 1);
                         map[idx] = map[idx].saturating_add(1);
@@ -181,10 +200,9 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                     }
                 }
 
-                state.set_current_execution_path(pcs);
+                state.set_current_execution_path(all_pcs);
 
-                // Update observers
-                let cause_loss = shift_losses.into_iter().any(|b| b);
+                let cause_loss = all_shift_losses.into_iter().any(|b| b);
                 self.observers.1 .1 .0.set_cause_loss(cause_loss);
                 if let TransactionStatus::Keep(ExecutionStatus::MoveAbort { location: _, code, .. }) = &result.status {
                     self.observers.1 .0.set_last(Some(*code));
@@ -202,13 +220,13 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 }
                 self.prev_loc = 0;
                 self.observers.1 .1 .0.set_cause_loss(false);
-                state.set_current_execution_path(pcs);
+                state.set_current_execution_path(all_pcs);
                 if let VMStatus::MoveAbort(ref _loc, code) = vm_status {
                     self.observers.1 .0.set_last(Some(code));
                 } else {
                     self.observers.1 .0.set_last(None);
                 }
-                let exit_kind = match outcome {
+                let exit_kind = match final_outcome {
                     ExecOutcomeKind::Ok => ExitKind::Ok,
                     ExecOutcomeKind::MoveAbort(_) => ExitKind::Ok,
                     ExecOutcomeKind::OutOfGas => ExitKind::Ok,

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use aptos_dynamic_transaction_composer::{CallArgument, TransactionComposer};
+use aptos_move_binary_format::access::ModuleAccess;
 use aptos_move_core_types::language_storage::TypeTag;
 use aptos_move_core_types::vm_status::{StatusCode, VMStatus};
 use aptos_move_vm_runtime::ModuleStorage;
@@ -12,7 +13,6 @@ use libafl::observers::map::{HitcountsMapObserver, OwnedMapObserver};
 use libafl::state::HasExecutions;
 use libafl_bolts::tuples::RefIndexable;
 use libafl_bolts::AsSliceMut;
-use aptos_move_binary_format::access::ModuleAccess;
 
 use crate::executor::aptos_custom_state::AptosCustomState;
 use crate::executor::custom_state_view::CustomStateView;
@@ -24,7 +24,7 @@ use crate::{AptosFuzzerInput, AptosFuzzerState};
 // Type aliases to simplify complex observer tuple types
 type AptosObservers = (
     HitcountsMapObserver<OwnedMapObserver<u8>>,
-    (AbortCodeObserver, (ShiftOverflowObserver, ()))
+    (AbortCodeObserver, (ShiftOverflowObserver, ())),
 );
 
 pub struct AptosMoveExecutor<EM, Z> {
@@ -55,18 +55,27 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         }
     }
 
-    pub fn total_instructions_executed(&self) -> u64 { self.total_instructions_executed }
+    pub fn total_instructions_executed(&self) -> u64 {
+        self.total_instructions_executed
+    }
 
     #[inline]
     fn hash32(bytes: &[u8]) -> u32 {
         // FNV-1a hash
         let mut hash: u32 = 0x811C9DC5;
-        for &b in bytes { hash ^= b as u32; hash = hash.wrapping_mul(0x01000193); }
+        for &b in bytes {
+            hash ^= b as u32;
+            hash = hash.wrapping_mul(0x01000193);
+        }
         hash
     }
 
-    pub fn pc_observer(&self) -> &HitcountsMapObserver<OwnedMapObserver<u8>> { &self.observers.0 }
-    pub fn pc_observer_mut(&mut self) -> &mut HitcountsMapObserver<OwnedMapObserver<u8>> { &mut self.observers.0 }
+    pub fn pc_observer(&self) -> &HitcountsMapObserver<OwnedMapObserver<u8>> {
+        &self.observers.0
+    }
+    pub fn pc_observer_mut(&mut self) -> &mut HitcountsMapObserver<OwnedMapObserver<u8>> {
+        &mut self.observers.0
+    }
 
     pub fn execute_transaction(
         &mut self,
@@ -82,12 +91,17 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         match &transaction {
             TransactionPayload::EntryFunction(_) | TransactionPayload::Script(_) => {
                 let view = CustomStateView::new(state);
-                let code_storage = aptos_vm_types::module_and_script_storage::AsAptosCodeStorage::as_aptos_code_storage(&view, state);
-                let (result, pcs, shifts, outcome) = self.aptos_vm.execute_user_payload_no_checking(state, &code_storage, &transaction, sender);
+                let code_storage =
+                    aptos_vm_types::module_and_script_storage::AsAptosCodeStorage::as_aptos_code_storage(&view, state);
+                let (result, pcs, shifts, outcome) =
+                    self.aptos_vm
+                        .execute_user_payload_no_checking(state, &code_storage, &transaction, sender);
                 let shift_losses: Vec<bool> = shifts.iter().map(|ev| ev.lost_high_bits).collect();
                 let res = match result {
                     Ok((write_set, events)) => Ok(TransactionResult {
-                        status: aptos_types::transaction::TransactionStatus::Keep(aptos_types::vm_status::KeptVMStatus::Executed.into()),
+                        status: aptos_types::transaction::TransactionStatus::Keep(
+                            aptos_types::vm_status::KeptVMStatus::Executed.into(),
+                        ),
                         gas_used: 0,
                         write_set,
                         events,
@@ -98,7 +112,11 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
                 (res, outcome, pcs, shift_losses)
             }
             _ => (
-                Err(VMStatus::Error { status_code: StatusCode::UNKNOWN_STATUS, sub_status: None, message: Some("Unsupported payload type for this executor".to_string()) }),
+                Err(VMStatus::Error {
+                    status_code: StatusCode::UNKNOWN_STATUS,
+                    sub_status: None,
+                    message: Some("Unsupported payload type for this executor".to_string()),
+                }),
                 ExecOutcomeKind::OtherError,
                 Vec::new(),
                 Vec::new(),
@@ -111,7 +129,9 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         input: &AptosFuzzerInput,
         state: &AptosCustomState,
     ) -> Option<TransactionPayload> {
-        if input.calls.is_empty() { return None; }
+        if input.calls.is_empty() {
+            return None;
+        }
         // Build the script using TransactionComposer
         let mut composer = TransactionComposer::single_signer();
         // Load module bytes from state into composer
@@ -126,12 +146,18 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         let mut prev_return_types: Vec<Vec<TypeTag>> = Vec::with_capacity(shaped.len());
         let mut prev_handles: Vec<Vec<CallArgument>> = Vec::with_capacity(shaped.len());
         for (idx_call, call) in shaped.iter().enumerate() {
-            let module_str = format!("{}::{}", call.module_id.address().to_standard_string(), call.module_id.name());
+            let module_str = format!(
+                "{}::{}",
+                call.module_id.address().to_standard_string(),
+                call.module_id.name()
+            );
             let function_str = call.function_name.to_string();
             let ty_args: Vec<String> = call.ty_args.iter().map(TypeTag::to_canonical_string).collect();
             let mut args = call.args.clone();
             // try to satisfy &T/&mut T by borrowing previous results with same TypeTag
-            if let Ok(Some(cm)) = state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+            if let Ok(Some(cm)) =
+                state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name())
+            {
                 let mut params = None;
                 let mut returns = None;
                 for def in cm.function_defs() {
@@ -166,24 +192,34 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
                                     ST::Struct(idx) => {
                                         let st = module.struct_handle_at(*idx);
                                         let mh = module.module_handle_at(st.module);
-                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                                            address: *module.address_identifier_at(mh.address),
-                                            module: module.identifier_at(mh.name).to_owned(),
-                                            name: module.identifier_at(st.name).to_owned(),
-                                            type_args: vec![],
-                                        })))
+                                        Some(TypeTag::Struct(Box::new(
+                                            aptos_move_core_types::language_storage::StructTag {
+                                                address: *module.address_identifier_at(mh.address),
+                                                module: module.identifier_at(mh.name).to_owned(),
+                                                name: module.identifier_at(st.name).to_owned(),
+                                                type_args: vec![],
+                                            },
+                                        )))
                                     }
                                     ST::StructInstantiation(idx, toks) => {
                                         let st = module.struct_handle_at(*idx);
                                         let mh = module.module_handle_at(st.module);
                                         let mut targs = Vec::with_capacity(toks.len());
-                                        for t2 in toks { if let Some(tag) = tag_of(module, t2, ty_args) { targs.push(tag) } else { return None } }
-                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                                            address: *module.address_identifier_at(mh.address),
-                                            module: module.identifier_at(mh.name).to_owned(),
-                                            name: module.identifier_at(st.name).to_owned(),
-                                            type_args: targs,
-                                        })))
+                                        for t2 in toks {
+                                            if let Some(tag) = tag_of(module, t2, ty_args) {
+                                                targs.push(tag)
+                                            } else {
+                                                return None;
+                                            }
+                                        }
+                                        Some(TypeTag::Struct(Box::new(
+                                            aptos_move_core_types::language_storage::StructTag {
+                                                address: *module.address_identifier_at(mh.address),
+                                                module: module.identifier_at(mh.name).to_owned(),
+                                                name: module.identifier_at(st.name).to_owned(),
+                                                type_args: targs,
+                                            },
+                                        )))
                                     }
                                     ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
                                     ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
@@ -229,14 +265,21 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
                         }
                     }
                     // compute and record return types for this call index after add
-                    if let Some(ret_toks) = returns { let _ = ret_toks; }
+                    if let Some(ret_toks) = returns {
+                        let _ = ret_toks;
+                    }
                 }
             }
             // add call and capture return handles
-            let ret_handles = match composer.add_batched_call(module_str, function_str, ty_args, args) { Ok(v) => v, Err(_) => return None };
+            let ret_handles = match composer.add_batched_call(module_str, function_str, ty_args, args) {
+                Ok(v) => v,
+                Err(_) => return None,
+            };
             // compute return type tags for this call
             let mut ret_types: Vec<TypeTag> = Vec::new();
-            if let Ok(Some(cm2)) = state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+            if let Ok(Some(cm2)) =
+                state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name())
+            {
                 for def in cm2.function_defs() {
                     let h = cm2.function_handle_at(def.function);
                     if cm2.identifier_at(h.name) == call.function_name.as_ident_str() {
@@ -263,30 +306,42 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
                                     ST::Struct(idx) => {
                                         let st = module.struct_handle_at(*idx);
                                         let mh = module.module_handle_at(st.module);
-                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                                            address: *module.address_identifier_at(mh.address),
-                                            module: module.identifier_at(mh.name).to_owned(),
-                                            name: module.identifier_at(st.name).to_owned(),
-                                            type_args: vec![],
-                                        })))
+                                        Some(TypeTag::Struct(Box::new(
+                                            aptos_move_core_types::language_storage::StructTag {
+                                                address: *module.address_identifier_at(mh.address),
+                                                module: module.identifier_at(mh.name).to_owned(),
+                                                name: module.identifier_at(st.name).to_owned(),
+                                                type_args: vec![],
+                                            },
+                                        )))
                                     }
                                     ST::StructInstantiation(idx, toks) => {
                                         let st = module.struct_handle_at(*idx);
                                         let mh = module.module_handle_at(st.module);
                                         let mut targs = Vec::with_capacity(toks.len());
-                                        for t2 in toks { if let Some(tag) = tag_of(module, t2, ty_args) { targs.push(tag) } else { return None } }
-                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                                            address: *module.address_identifier_at(mh.address),
-                                            module: module.identifier_at(mh.name).to_owned(),
-                                            name: module.identifier_at(st.name).to_owned(),
-                                            type_args: targs,
-                                        })))
+                                        for t2 in toks {
+                                            if let Some(tag) = tag_of(module, t2, ty_args) {
+                                                targs.push(tag)
+                                            } else {
+                                                return None;
+                                            }
+                                        }
+                                        Some(TypeTag::Struct(Box::new(
+                                            aptos_move_core_types::language_storage::StructTag {
+                                                address: *module.address_identifier_at(mh.address),
+                                                module: module.identifier_at(mh.name).to_owned(),
+                                                name: module.identifier_at(st.name).to_owned(),
+                                                type_args: targs,
+                                            },
+                                        )))
                                     }
                                     ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
                                     ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
                                 }
                             }
-                            if let Some(tag) = tag_of(&cm2, rt, &call.ty_args) { ret_types.push(tag); }
+                            if let Some(tag) = tag_of(&cm2, rt, &call.ty_args) {
+                                ret_types.push(tag);
+                            }
                         }
                         break;
                     }
@@ -295,13 +350,23 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
             prev_handles.push(ret_handles);
             prev_return_types.push(ret_types);
         }
-        let script_bytes = match composer.generate_batched_calls(true) { Ok(b) => b, Err(_) => return None };
-        let script = match bcs::from_bytes::<aptos_types::transaction::Script>(&script_bytes) { Ok(s) => s, Err(_) => return None };
+        let script_bytes = match composer.generate_batched_calls(true) {
+            Ok(b) => b,
+            Err(_) => return None,
+        };
+        let script = match bcs::from_bytes::<aptos_types::transaction::Script>(&script_bytes) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
         Some(TransactionPayload::Script(script))
     }
 }
 
-impl<EM, Z> Default for AptosMoveExecutor<EM, Z> { fn default() -> Self { Self::new() } }
+impl<EM, Z> Default for AptosMoveExecutor<EM, Z> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExecutor<EM, Z> {
     fn run_target(
@@ -312,24 +377,33 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
         input: &AptosFuzzerInput,
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
-        if input.calls.is_empty() { return Ok(ExitKind::Ok); }
-        // PCs from VM are packed u64 per step: upper 32 bits = function hash, lower 32 bits = local pc (u16 widened)
+        if input.calls.is_empty() {
+            return Ok(ExitKind::Ok);
+        }
+        // PCs from VM are packed u64 per step: upper 32 bits = function hash, lower 32
+        // bits = local pc (u16 widened)
         let mut all_pcs = Vec::new();
         let mut all_shift_losses = Vec::new();
         let mut final_outcome = ExecOutcomeKind::Ok;
         let mut final_result = None;
-        let payload = match self.calls_to_script_payload(input, state.aptos_state()) { Some(p) => p, None => return Ok(ExitKind::Ok) };
-        let (result, outcome, pcs, shift_losses) = self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
-            all_pcs.extend(pcs);
-            all_shift_losses.extend(shift_losses);
-            final_outcome = outcome;
-            final_result = Some(result);
+        let payload = match self.calls_to_script_payload(input, state.aptos_state()) {
+            Some(p) => p,
+            None => return Ok(ExitKind::Ok),
+        };
+        let (result, outcome, pcs, shift_losses) =
+            self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
+        all_pcs.extend(pcs);
+        all_shift_losses.extend(shift_losses);
+        final_outcome = outcome;
+        final_result = Some(result);
         *state.executions_mut() += 1;
         match final_result.unwrap() {
             Ok(result) => {
                 self.success_count += 1;
                 let map = self.observers.0.as_slice_mut();
-                for byte in map.iter_mut() { *byte = 0; }
+                for byte in map.iter_mut() {
+                    *byte = 0;
+                }
                 self.prev_loc = 0;
                 // Convert packed u64 to hashed u32 tokens for coverage and path recording
                 self.total_instructions_executed += all_pcs.len() as u64;
@@ -356,13 +430,17 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                 self.observers.1 .1 .0.set_cause_loss(cause_loss);
                 if let TransactionStatus::Keep(ExecutionStatus::MoveAbort { location: _, code, .. }) = &result.status {
                     self.observers.1 .0.set_last(Some(*code));
-                } else { self.observers.1 .0.set_last(None); }
+                } else {
+                    self.observers.1 .0.set_last(None);
+                }
                 Ok(ExitKind::Ok)
             }
             Err(vm_status) => {
                 self.error_count += 1;
                 let map = self.observers.0.as_slice_mut();
-                for byte in map.iter_mut() { *byte = 0; }
+                for byte in map.iter_mut() {
+                    *byte = 0;
+                }
                 self.prev_loc = 0;
                 self.observers.1 .1 .0.set_cause_loss(false);
                 // On error, still record hashed tokens for current path (may be empty)
@@ -376,7 +454,11 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                     tokens.push(Self::hash32(&buf));
                 }
                 state.set_current_execution_path(tokens);
-                if let VMStatus::MoveAbort(ref _loc, code) = vm_status { self.observers.1 .0.set_last(Some(code)); } else { self.observers.1 .0.set_last(None); }
+                if let VMStatus::MoveAbort(ref _loc, code) = vm_status {
+                    self.observers.1 .0.set_last(Some(code));
+                } else {
+                    self.observers.1 .0.set_last(None);
+                }
                 let exit_kind = match final_outcome {
                     ExecOutcomeKind::Ok => ExitKind::Ok,
                     ExecOutcomeKind::MoveAbort(_) => ExitKind::Ok,
@@ -393,6 +475,10 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
 
 impl<EM, Z> HasObservers for AptosMoveExecutor<EM, Z> {
     type Observers = AptosObservers;
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> { RefIndexable::from(&self.observers) }
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> { RefIndexable::from(&mut self.observers) }
+    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
+        RefIndexable::from(&self.observers)
+    }
+    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
+        RefIndexable::from(&mut self.observers)
+    }
 }

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use aptos_dynamic_transaction_composer::TransactionComposer;
+use aptos_dynamic_transaction_composer::{CallArgument, TransactionComposer};
 use aptos_move_core_types::language_storage::TypeTag;
 use aptos_move_core_types::vm_status::{StatusCode, VMStatus};
 use aptos_move_vm_runtime::ModuleStorage;
@@ -12,6 +12,7 @@ use libafl::observers::map::{HitcountsMapObserver, OwnedMapObserver};
 use libafl::state::HasExecutions;
 use libafl_bolts::tuples::RefIndexable;
 use libafl_bolts::AsSliceMut;
+use aptos_move_binary_format::access::ModuleAccess;
 
 use crate::executor::aptos_custom_state::AptosCustomState;
 use crate::executor::custom_state_view::CustomStateView;
@@ -23,7 +24,7 @@ use crate::{AptosFuzzerInput, AptosFuzzerState};
 // Type aliases to simplify complex observer tuple types
 type AptosObservers = (
     HitcountsMapObserver<OwnedMapObserver<u8>>,
-    (AbortCodeObserver, (ShiftOverflowObserver, ())),
+    (AbortCodeObserver, (ShiftOverflowObserver, ()))
 );
 
 pub struct AptosMoveExecutor<EM, Z> {
@@ -54,27 +55,18 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         }
     }
 
-    pub fn total_instructions_executed(&self) -> u64 {
-        self.total_instructions_executed
-    }
+    pub fn total_instructions_executed(&self) -> u64 { self.total_instructions_executed }
 
     #[inline]
     fn hash32(bytes: &[u8]) -> u32 {
         // FNV-1a hash
         let mut hash: u32 = 0x811C9DC5;
-        for &b in bytes {
-            hash ^= b as u32;
-            hash = hash.wrapping_mul(0x01000193);
-        }
+        for &b in bytes { hash ^= b as u32; hash = hash.wrapping_mul(0x01000193); }
         hash
     }
 
-    pub fn pc_observer(&self) -> &HitcountsMapObserver<OwnedMapObserver<u8>> {
-        &self.observers.0
-    }
-    pub fn pc_observer_mut(&mut self) -> &mut HitcountsMapObserver<OwnedMapObserver<u8>> {
-        &mut self.observers.0
-    }
+    pub fn pc_observer(&self) -> &HitcountsMapObserver<OwnedMapObserver<u8>> { &self.observers.0 }
+    pub fn pc_observer_mut(&mut self) -> &mut HitcountsMapObserver<OwnedMapObserver<u8>> { &mut self.observers.0 }
 
     pub fn execute_transaction(
         &mut self,
@@ -90,19 +82,12 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         match &transaction {
             TransactionPayload::EntryFunction(_) | TransactionPayload::Script(_) => {
                 let view = CustomStateView::new(state);
-                let code_storage =
-                    aptos_vm_types::module_and_script_storage::AsAptosCodeStorage::as_aptos_code_storage(&view, state);
-
-                let (result, pcs, shifts, outcome) =
-                    self.aptos_vm
-                        .execute_user_payload_no_checking(state, &code_storage, &transaction, sender);
+                let code_storage = aptos_vm_types::module_and_script_storage::AsAptosCodeStorage::as_aptos_code_storage(&view, state);
+                let (result, pcs, shifts, outcome) = self.aptos_vm.execute_user_payload_no_checking(state, &code_storage, &transaction, sender);
                 let shift_losses: Vec<bool> = shifts.iter().map(|ev| ev.lost_high_bits).collect();
-
                 let res = match result {
                     Ok((write_set, events)) => Ok(TransactionResult {
-                        status: aptos_types::transaction::TransactionStatus::Keep(
-                            aptos_types::vm_status::KeptVMStatus::Executed.into(),
-                        ),
+                        status: aptos_types::transaction::TransactionStatus::Keep(aptos_types::vm_status::KeptVMStatus::Executed.into()),
                         gas_used: 0,
                         write_set,
                         events,
@@ -113,11 +98,7 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
                 (res, outcome, pcs, shift_losses)
             }
             _ => (
-                Err(VMStatus::Error {
-                    status_code: StatusCode::UNKNOWN_STATUS,
-                    sub_status: None,
-                    message: Some("Unsupported payload type for this executor".to_string()),
-                }),
+                Err(VMStatus::Error { status_code: StatusCode::UNKNOWN_STATUS, sub_status: None, message: Some("Unsupported payload type for this executor".to_string()) }),
                 ExecOutcomeKind::OtherError,
                 Vec::new(),
                 Vec::new(),
@@ -130,52 +111,197 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
         input: &AptosFuzzerInput,
         state: &AptosCustomState,
     ) -> Option<TransactionPayload> {
-        if input.calls.is_empty() {
-            return None;
-        }
-
+        if input.calls.is_empty() { return None; }
         // Build the script using TransactionComposer
         let mut composer = TransactionComposer::single_signer();
-
         // Load module bytes from state into composer
         for call in &input.calls {
             if let Ok(Some(bytes)) = state.unmetered_get_module_bytes(call.module_id.address(), call.module_id.name()) {
                 let _ = composer.store_module(bytes.to_vec());
             }
         }
-
-        // Add each batched call with ty args and arguments
-        for call in &input.calls {
-            let module_str = format!(
-                "{}::{}",
-                call.module_id.address().to_standard_string(),
-                call.module_id.name()
-            );
+        // Use shaped calls from input
+        let shaped = input.shaped_calls(state);
+        // Track previous return type tags and composer handles
+        let mut prev_return_types: Vec<Vec<TypeTag>> = Vec::with_capacity(shaped.len());
+        let mut prev_handles: Vec<Vec<CallArgument>> = Vec::with_capacity(shaped.len());
+        for (idx_call, call) in shaped.iter().enumerate() {
+            let module_str = format!("{}::{}", call.module_id.address().to_standard_string(), call.module_id.name());
             let function_str = call.function_name.to_string();
             let ty_args: Vec<String> = call.ty_args.iter().map(TypeTag::to_canonical_string).collect();
-            let args = call.args.clone();
-            if composer.add_batched_call(module_str, function_str, ty_args, args).is_err() {
-                return None;
+            let mut args = call.args.clone();
+            // try to satisfy &T/&mut T by borrowing previous results with same TypeTag
+            if let Ok(Some(cm)) = state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+                let mut params = None;
+                let mut returns = None;
+                for def in cm.function_defs() {
+                    let h = cm.function_handle_at(def.function);
+                    if cm.identifier_at(h.name) == call.function_name.as_ident_str() {
+                        params = Some(cm.signature_at(h.parameters).0.clone());
+                        returns = Some(cm.signature_at(h.return_).0.clone());
+                        break;
+                    }
+                }
+                if let Some(param_toks) = params {
+                    for (i, arg) in args.iter_mut().enumerate() {
+                        if let Some(tok) = param_toks.get(i) {
+                            use aptos_move_binary_format::file_format::SignatureToken as ST;
+                            // helper: convert ST->TypeTag with current call.ty_args
+                            fn tag_of(
+                                module: &aptos_move_binary_format::CompiledModule,
+                                t: &aptos_move_binary_format::file_format::SignatureToken,
+                                ty_args: &[TypeTag],
+                            ) -> Option<TypeTag> {
+                                match t {
+                                    ST::Bool => Some(TypeTag::Bool),
+                                    ST::U8 => Some(TypeTag::U8),
+                                    ST::U16 => Some(TypeTag::U16),
+                                    ST::U32 => Some(TypeTag::U32),
+                                    ST::U64 => Some(TypeTag::U64),
+                                    ST::U128 => Some(TypeTag::U128),
+                                    ST::U256 => Some(TypeTag::U256),
+                                    ST::Address => Some(TypeTag::Address),
+                                    ST::Signer => Some(TypeTag::Signer),
+                                    ST::Vector(x) => tag_of(module, x, ty_args).map(|t| TypeTag::Vector(Box::new(t))),
+                                    ST::Struct(idx) => {
+                                        let st = module.struct_handle_at(*idx);
+                                        let mh = module.module_handle_at(st.module);
+                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                                            address: *module.address_identifier_at(mh.address),
+                                            module: module.identifier_at(mh.name).to_owned(),
+                                            name: module.identifier_at(st.name).to_owned(),
+                                            type_args: vec![],
+                                        })))
+                                    }
+                                    ST::StructInstantiation(idx, toks) => {
+                                        let st = module.struct_handle_at(*idx);
+                                        let mh = module.module_handle_at(st.module);
+                                        let mut targs = Vec::with_capacity(toks.len());
+                                        for t2 in toks { if let Some(tag) = tag_of(module, t2, ty_args) { targs.push(tag) } else { return None } }
+                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                                            address: *module.address_identifier_at(mh.address),
+                                            module: module.identifier_at(mh.name).to_owned(),
+                                            name: module.identifier_at(st.name).to_owned(),
+                                            type_args: targs,
+                                        })))
+                                    }
+                                    ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
+                                    ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
+                                }
+                            }
+                            match tok {
+                                ST::Reference(inner) => {
+                                    if let Some(base) = tag_of(&cm, inner, &call.ty_args) {
+                                        // scan previous returns for same TypeTag
+                                        'outer_ref: for (j, rets) in prev_return_types.iter().enumerate().rev() {
+                                            if let Some(k) = rets.iter().position(|tt| *tt == base) {
+                                                // take handle and borrow
+                                                if let Some(hs) = prev_handles.get(j) {
+                                                    if let Some(h) = hs.get(k) {
+                                                        if let Ok(borrowed) = h.borrow() {
+                                                            *arg = borrowed;
+                                                            break 'outer_ref;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                ST::MutableReference(inner) => {
+                                    if let Some(base) = tag_of(&cm, inner, &call.ty_args) {
+                                        'outer_mref: for (j, rets) in prev_return_types.iter().enumerate().rev() {
+                                            if let Some(k) = rets.iter().position(|tt| *tt == base) {
+                                                if let Some(hs) = prev_handles.get(j) {
+                                                    if let Some(h) = hs.get(k) {
+                                                        if let Ok(borrowed) = h.borrow_mut() {
+                                                            *arg = borrowed;
+                                                            break 'outer_mref;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    // compute and record return types for this call index after add
+                    if let Some(ret_toks) = returns { let _ = ret_toks; }
+                }
             }
+            // add call and capture return handles
+            let ret_handles = match composer.add_batched_call(module_str, function_str, ty_args, args) { Ok(v) => v, Err(_) => return None };
+            // compute return type tags for this call
+            let mut ret_types: Vec<TypeTag> = Vec::new();
+            if let Ok(Some(cm2)) = state.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+                for def in cm2.function_defs() {
+                    let h = cm2.function_handle_at(def.function);
+                    if cm2.identifier_at(h.name) == call.function_name.as_ident_str() {
+                        let rts = cm2.signature_at(h.return_).0.clone();
+                        for rt in rts.iter() {
+                            // reuse small helper
+                            use aptos_move_binary_format::file_format::SignatureToken as ST;
+                            fn tag_of(
+                                module: &aptos_move_binary_format::CompiledModule,
+                                t: &aptos_move_binary_format::file_format::SignatureToken,
+                                ty_args: &[TypeTag],
+                            ) -> Option<TypeTag> {
+                                match t {
+                                    ST::Bool => Some(TypeTag::Bool),
+                                    ST::U8 => Some(TypeTag::U8),
+                                    ST::U16 => Some(TypeTag::U16),
+                                    ST::U32 => Some(TypeTag::U32),
+                                    ST::U64 => Some(TypeTag::U64),
+                                    ST::U128 => Some(TypeTag::U128),
+                                    ST::U256 => Some(TypeTag::U256),
+                                    ST::Address => Some(TypeTag::Address),
+                                    ST::Signer => Some(TypeTag::Signer),
+                                    ST::Vector(x) => tag_of(module, x, ty_args).map(|t| TypeTag::Vector(Box::new(t))),
+                                    ST::Struct(idx) => {
+                                        let st = module.struct_handle_at(*idx);
+                                        let mh = module.module_handle_at(st.module);
+                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                                            address: *module.address_identifier_at(mh.address),
+                                            module: module.identifier_at(mh.name).to_owned(),
+                                            name: module.identifier_at(st.name).to_owned(),
+                                            type_args: vec![],
+                                        })))
+                                    }
+                                    ST::StructInstantiation(idx, toks) => {
+                                        let st = module.struct_handle_at(*idx);
+                                        let mh = module.module_handle_at(st.module);
+                                        let mut targs = Vec::with_capacity(toks.len());
+                                        for t2 in toks { if let Some(tag) = tag_of(module, t2, ty_args) { targs.push(tag) } else { return None } }
+                                        Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                                            address: *module.address_identifier_at(mh.address),
+                                            module: module.identifier_at(mh.name).to_owned(),
+                                            name: module.identifier_at(st.name).to_owned(),
+                                            type_args: targs,
+                                        })))
+                                    }
+                                    ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
+                                    ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
+                                }
+                            }
+                            if let Some(tag) = tag_of(&cm2, rt, &call.ty_args) { ret_types.push(tag); }
+                        }
+                        break;
+                    }
+                }
+            }
+            prev_handles.push(ret_handles);
+            prev_return_types.push(ret_types);
         }
-
-        let script_bytes = match composer.generate_batched_calls(true) {
-            Ok(b) => b,
-            Err(_) => return None,
-        };
-        let script = match bcs::from_bytes::<aptos_types::transaction::Script>(&script_bytes) {
-            Ok(s) => s,
-            Err(_) => return None,
-        };
+        let script_bytes = match composer.generate_batched_calls(true) { Ok(b) => b, Err(_) => return None };
+        let script = match bcs::from_bytes::<aptos_types::transaction::Script>(&script_bytes) { Ok(s) => s, Err(_) => return None };
         Some(TransactionPayload::Script(script))
     }
 }
 
-impl<EM, Z> Default for AptosMoveExecutor<EM, Z> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+impl<EM, Z> Default for AptosMoveExecutor<EM, Z> { fn default() -> Self { Self::new() } }
 
 impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExecutor<EM, Z> {
     fn run_target(
@@ -186,47 +312,28 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
         input: &AptosFuzzerInput,
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
-
-        if input.calls.is_empty() {
-            return Ok(ExitKind::Ok);
-        }
-
+        if input.calls.is_empty() { return Ok(ExitKind::Ok); }
         let mut all_pcs = Vec::new();
         let mut all_shift_losses = Vec::new();
         let mut final_outcome = ExecOutcomeKind::Ok;
         let mut final_result = None;
-
-        // Build a single Script payload from all calls and execute once
-        let payload = match self.calls_to_script_payload(input, state.aptos_state()) {
-            Some(p) => p,
-            None => return Ok(ExitKind::Ok),
-        };
-
-        let (result, outcome, pcs, shift_losses) =
-            self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
-        all_pcs.extend(pcs);
-        all_shift_losses.extend(shift_losses);
-        final_outcome = outcome;
-        final_result = Some(result);
-
-        // Update execution counter
+        let payload = match self.calls_to_script_payload(input, state.aptos_state()) { Some(p) => p, None => return Ok(ExitKind::Ok) };
+        let (result, outcome, pcs, shift_losses) = self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
+            all_pcs.extend(pcs);
+            all_shift_losses.extend(shift_losses);
+            final_outcome = outcome;
+            final_result = Some(result);
         *state.executions_mut() += 1;
-
         match final_result.unwrap() {
             Ok(result) => {
                 self.success_count += 1;
                 let map = self.observers.0.as_slice_mut();
-                for byte in map.iter_mut() {
-                    *byte = 0;
-                }
+                for byte in map.iter_mut() { *byte = 0; }
                 self.prev_loc = 0;
-
                 self.total_instructions_executed += all_pcs.len() as u64;
-
                 {
                     let cumulative_map = state.cumulative_coverage_mut();
                     for &pc in &all_pcs {
-                        // PCs are now global in the VM trace; use directly
                         let cur_id = pc;
                         let idx = ((cur_id ^ self.prev_loc) as usize) & (MAP_SIZE - 1);
                         map[idx] = map[idx].saturating_add(1);
@@ -234,33 +341,22 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
                         self.prev_loc = cur_id >> 1;
                     }
                 }
-
                 state.set_current_execution_path(all_pcs);
-
                 let cause_loss = all_shift_losses.into_iter().any(|b| b);
                 self.observers.1 .1 .0.set_cause_loss(cause_loss);
                 if let TransactionStatus::Keep(ExecutionStatus::MoveAbort { location: _, code, .. }) = &result.status {
                     self.observers.1 .0.set_last(Some(*code));
-                } else {
-                    self.observers.1 .0.set_last(None);
-                }
-
+                } else { self.observers.1 .0.set_last(None); }
                 Ok(ExitKind::Ok)
             }
             Err(vm_status) => {
                 self.error_count += 1;
                 let map = self.observers.0.as_slice_mut();
-                for byte in map.iter_mut() {
-                    *byte = 0;
-                }
+                for byte in map.iter_mut() { *byte = 0; }
                 self.prev_loc = 0;
                 self.observers.1 .1 .0.set_cause_loss(false);
                 state.set_current_execution_path(all_pcs);
-                if let VMStatus::MoveAbort(ref _loc, code) = vm_status {
-                    self.observers.1 .0.set_last(Some(code));
-                } else {
-                    self.observers.1 .0.set_last(None);
-                }
+                if let VMStatus::MoveAbort(ref _loc, code) = vm_status { self.observers.1 .0.set_last(Some(code)); } else { self.observers.1 .0.set_last(None); }
                 let exit_kind = match final_outcome {
                     ExecOutcomeKind::Ok => ExitKind::Ok,
                     ExecOutcomeKind::MoveAbort(_) => ExitKind::Ok,
@@ -277,12 +373,6 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
 
 impl<EM, Z> HasObservers for AptosMoveExecutor<EM, Z> {
     type Observers = AptosObservers;
-
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
-        RefIndexable::from(&self.observers)
-    }
-
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
-        RefIndexable::from(&mut self.observers)
-    }
+    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> { RefIndexable::from(&self.observers) }
+    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> { RefIndexable::from(&mut self.observers) }
 }

--- a/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
+++ b/crates/aptos-fuzzer/src/executor/aptos_move_executor.rs
@@ -1,6 +1,9 @@
 use std::marker::PhantomData;
 
+use aptos_dynamic_transaction_composer::TransactionComposer;
+use aptos_move_core_types::language_storage::TypeTag;
 use aptos_move_core_types::vm_status::{StatusCode, VMStatus};
+use aptos_move_vm_runtime::ModuleStorage;
 use aptos_types::transaction::{ExecutionStatus, TransactionPayload, TransactionStatus};
 use aptos_vm::aptos_vm::{ExecOutcomeKind, FUZZER_SENDER};
 use aptos_vm::AptosVM;
@@ -9,6 +12,7 @@ use libafl::observers::map::{HitcountsMapObserver, OwnedMapObserver};
 use libafl::state::HasExecutions;
 use libafl_bolts::tuples::RefIndexable;
 use libafl_bolts::AsSliceMut;
+
 use crate::executor::aptos_custom_state::AptosCustomState;
 use crate::executor::custom_state_view::CustomStateView;
 use crate::executor::types::TransactionResult;
@@ -120,6 +124,50 @@ impl<EM, Z> AptosMoveExecutor<EM, Z> {
             ),
         }
     }
+
+    fn calls_to_script_payload(
+        &self,
+        input: &AptosFuzzerInput,
+        state: &AptosCustomState,
+    ) -> Option<TransactionPayload> {
+        if input.calls.is_empty() {
+            return None;
+        }
+
+        // Build the script using TransactionComposer
+        let mut composer = TransactionComposer::single_signer();
+
+        // Load module bytes from state into composer
+        for call in &input.calls {
+            if let Ok(Some(bytes)) = state.unmetered_get_module_bytes(call.module_id.address(), call.module_id.name()) {
+                let _ = composer.store_module(bytes.to_vec());
+            }
+        }
+
+        // Add each batched call with ty args and arguments
+        for call in &input.calls {
+            let module_str = call.module_id.to_string();
+            let function_str = call.function_name.to_string();
+            let ty_args: Vec<String> = call.ty_args.iter().map(TypeTag::to_canonical_string).collect();
+            let args = call.args.clone();
+            if composer
+                .add_batched_call(module_str, function_str, ty_args, args)
+                .is_err()
+            {
+                return None;
+            }
+        }
+
+        let script_bytes = match composer.generate_batched_calls(true) {
+            Ok(b) => b,
+            Err(_) => return None,
+        };
+        let script = match bcs::from_bytes::<aptos_types::transaction::Script>(&script_bytes) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+        Some(TransactionPayload::Script(script))
+    }
 }
 
 impl<EM, Z> Default for AptosMoveExecutor<EM, Z> {
@@ -137,33 +185,28 @@ impl<EM, Z> Executor<EM, AptosFuzzerInput, AptosFuzzerState, Z> for AptosMoveExe
         input: &AptosFuzzerInput,
     ) -> Result<ExitKind, libafl::Error> {
         state.clear_current_execution_path();
-        
+
         if input.calls.is_empty() {
             return Ok(ExitKind::Ok);
         }
-        
+
         let mut all_pcs = Vec::new();
         let mut all_shift_losses = Vec::new();
         let mut final_outcome = ExecOutcomeKind::Ok;
         let mut final_result = None;
-        
-        // Execute each call in sequence
-        for call in &input.calls {
-            let entry_func = call.to_entry_function();
-            let payload = TransactionPayload::EntryFunction(entry_func);
-            let (result, outcome, pcs, shift_losses) =
-                self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
-            
-            all_pcs.extend(pcs);
-            all_shift_losses.extend(shift_losses);
-            final_outcome = outcome;
-            final_result = Some(result);
-            
-            // Stop execution on error
-            if final_result.as_ref().unwrap().is_err() {
-                break;
-            }
-        }
+
+        // Build a single Script payload from all calls and execute once
+        let payload = match self.calls_to_script_payload(input, state.aptos_state()) {
+            Some(p) => p,
+            None => return Ok(ExitKind::Ok),
+        };
+
+        let (result, outcome, pcs, shift_losses) =
+            self.execute_transaction(payload, state.aptos_state(), Some(FUZZER_SENDER));
+        all_pcs.extend(pcs);
+        all_shift_losses.extend(shift_losses);
+        final_outcome = outcome;
+        final_result = Some(result);
 
         // Update execution counter
         *state.executions_mut() += 1;

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -1,76 +1,53 @@
+use aptos_dynamic_transaction_composer::CallArgument;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
-use aptos_types::transaction::EntryFunction;
 use libafl::inputs::Input;
 use serde::{Deserialize, Serialize};
 
-/// Represents a single function call with all necessary parameters.
+/// Represents a single function call with batched-call compatible arguments.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct FuncCall {
+pub struct Call {
     pub module_id: ModuleId,
     pub function_name: Identifier,
     pub ty_args: Vec<TypeTag>,
-    pub bcs_args: Vec<Vec<u8>>,
+    pub args: Vec<CallArgument>,
 }
 
-impl FuncCall {
-    pub fn new(
-        module_id: ModuleId,
-        function_name: Identifier,
-        ty_args: Vec<TypeTag>,
-        bcs_args: Vec<Vec<u8>>,
-    ) -> Self {
+impl Call {
+    pub fn new(module_id: ModuleId, function_name: Identifier, ty_args: Vec<TypeTag>, args: Vec<CallArgument>) -> Self {
         Self {
             module_id,
             function_name,
             ty_args,
-            bcs_args,
+            args,
         }
-    }
-    
-    /// Convert to EntryFunction for execution
-    pub fn to_entry_function(&self) -> EntryFunction {
-        EntryFunction::new(
-            self.module_id.clone(),
-            self.function_name.clone(),
-            self.ty_args.clone(),
-            self.bcs_args.clone(),
-        )
     }
 }
 
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct AptosFuzzerInput {
-    pub calls: Vec<FuncCall>,
+    pub calls: Vec<Call>,
 }
 
 impl Input for AptosFuzzerInput {}
 
 impl AptosFuzzerInput {
-    pub fn new(call: FuncCall) -> Self {
+    pub fn new(call: Call) -> Self {
         Self { calls: vec![call] }
     }
-    
-    pub fn from_calls(calls: Vec<FuncCall>) -> Self {
+
+    pub fn from_calls(calls: Vec<Call>) -> Self {
         Self { calls }
     }
-    
-    pub fn from_entry_function(entry_func: EntryFunction) -> Self {
-        let (module_id, function_name, ty_args, bcs_args) = entry_func.into_inner();
-        Self {
-            calls: vec![FuncCall::new(module_id, function_name, ty_args, bcs_args)],
-        }
-    }
-    
-    pub fn push(&mut self, call: FuncCall) {
+
+    pub fn push(&mut self, call: Call) {
         self.calls.push(call);
     }
-    
+
     pub fn len(&self) -> usize {
         self.calls.len()
     }
-    
+
     pub fn is_empty(&self) -> bool {
         self.calls.is_empty()
     }

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -2,15 +2,13 @@ use aptos_types::transaction::TransactionPayload;
 use libafl::inputs::Input;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct AptosFuzzerInput {
     payload: TransactionPayload,
 }
 
 impl Input for AptosFuzzerInput {}
 
-// Currently we only support TransactionPayload::EntryFunction
-// TODO: add script
 impl AptosFuzzerInput {
     pub fn new(payload: TransactionPayload) -> Self {
         Self { payload }

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -42,15 +42,15 @@ impl AptosFuzzerInput {
     pub fn new(call: Call) -> Self {
         Self { calls: vec![call] }
     }
-
+    
     pub fn from_calls(calls: Vec<Call>) -> Self {
         Self { calls }
     }
-
+    
     pub fn push(&mut self, call: Call) {
         self.calls.push(call);
     }
-
+    
     pub fn len(&self) -> usize { self.calls.len() }
     pub fn is_empty(&self) -> bool { self.calls.is_empty() }
 

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -1,24 +1,32 @@
-use aptos_types::transaction::TransactionPayload;
+use aptos_types::transaction::EntryFunction;
 use libafl::inputs::Input;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct AptosFuzzerInput {
-    payload: TransactionPayload,
+    pub calls: Vec<EntryFunction>,
 }
 
 impl Input for AptosFuzzerInput {}
 
 impl AptosFuzzerInput {
-    pub fn new(payload: TransactionPayload) -> Self {
-        Self { payload }
+    pub fn new(call: EntryFunction) -> Self {
+        Self { calls: vec![call] }
     }
-
-    pub fn payload(&self) -> &TransactionPayload {
-        &self.payload
+    
+    pub fn from_calls(calls: Vec<EntryFunction>) -> Self {
+        Self { calls }
     }
-
-    pub fn payload_mut(&mut self) -> &mut TransactionPayload {
-        &mut self.payload
+    
+    pub fn push(&mut self, call: EntryFunction) {
+        self.calls.push(call);
+    }
+    
+    pub fn len(&self) -> usize {
+        self.calls.len()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.calls.is_empty()
     }
 }

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -1,15 +1,13 @@
 use aptos_dynamic_transaction_composer::CallArgument;
-use aptos_move_core_types::identifier::Identifier;
-use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
-use libafl::inputs::Input;
-use serde::{Deserialize, Serialize};
-
 // new imports for shaping
 use aptos_move_binary_format::access::ModuleAccess;
+use aptos_move_core_types::identifier::{IdentStr, Identifier};
+use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
+use aptos_move_core_types::value::{MoveStruct, MoveValue};
 use aptos_move_vm_runtime::ModuleStorage;
 use aptos_vm::aptos_vm::FUZZER_SENDER;
-use aptos_move_core_types::value::{MoveStruct, MoveValue};
-use aptos_move_core_types::identifier::IdentStr;
+use libafl::inputs::Input;
+use serde::{Deserialize, Serialize};
 
 /// Represents a single function call with batched-call compatible arguments.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
@@ -42,26 +40,33 @@ impl AptosFuzzerInput {
     pub fn new(call: Call) -> Self {
         Self { calls: vec![call] }
     }
-    
+
     pub fn from_calls(calls: Vec<Call>) -> Self {
         Self { calls }
     }
-    
+
     pub fn push(&mut self, call: Call) {
         self.calls.push(call);
     }
-    
-    pub fn len(&self) -> usize { self.calls.len() }
-    pub fn is_empty(&self) -> bool { self.calls.is_empty() }
 
-    /// Return a copy of `calls` with arguments shaped to minimal deserializable BCS
-    /// using module metadata from the provided storage.
+    pub fn len(&self) -> usize {
+        self.calls.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.calls.is_empty()
+    }
+
+    /// Return a copy of `calls` with arguments shaped to minimal deserializable
+    /// BCS using module metadata from the provided storage.
     pub fn shaped_calls<S: ModuleStorage>(&self, storage: &S) -> Vec<Call> {
         let mut out = Vec::with_capacity(self.calls.len());
-        // Note: &T/&mut T borrowing from previous results is handled during composing in executor
+        // Note: &T/&mut T borrowing from previous results is handled during composing
+        // in executor
         for call in &self.calls {
             let mut shaped_call = call.clone();
-            if let Ok(Some(cm)) = storage.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+            if let Ok(Some(cm)) =
+                storage.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name())
+            {
                 // locate function handle
                 let mut params: Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> = None;
                 let mut returns: Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> = None;
@@ -81,44 +86,93 @@ impl AptosFuzzerInput {
                             // &signer / &mut signer
                             (Some(t), _) if is_signer_reference(t) => CallArgument::Signer(0),
                             // value Signer
-                            (Some(aptos_move_binary_format::file_format::SignatureToken::Signer), _) => CallArgument::Signer(0),
+                            (Some(aptos_move_binary_format::file_format::SignatureToken::Signer), _) => {
+                                CallArgument::Signer(0)
+                            }
                             // general &T / &mut T: leave Raw shaping; borrowing is composed later
-                            (Some(aptos_move_binary_format::file_format::SignatureToken::Reference(inner)), prev_or_raw) => {
+                            (
+                                Some(aptos_move_binary_format::file_format::SignatureToken::Reference(inner)),
+                                prev_or_raw,
+                            ) => {
                                 if let Some(base_tag) = type_tag_from_signature(&cm, inner, &call.ty_args) {
                                     match prev_or_raw {
                                         CallArgument::Raw(bytes) => {
-                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
-                                        },
+                                            if !bytes.is_empty() {
+                                                CallArgument::Raw(bytes)
+                                            } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) {
+                                                CallArgument::Raw(minb)
+                                            } else {
+                                                CallArgument::Raw(vec![])
+                                            }
+                                        }
                                         other => other,
                                     }
-                                } else { prev_or_raw }
-                            },
-                            (Some(aptos_move_binary_format::file_format::SignatureToken::MutableReference(inner)), prev_or_raw) => {
+                                } else {
+                                    prev_or_raw
+                                }
+                            }
+                            (
+                                Some(aptos_move_binary_format::file_format::SignatureToken::MutableReference(inner)),
+                                prev_or_raw,
+                            ) => {
                                 if let Some(base_tag) = type_tag_from_signature(&cm, inner, &call.ty_args) {
                                     match prev_or_raw {
                                         CallArgument::Raw(bytes) => {
-                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
-                                        },
+                                            if !bytes.is_empty() {
+                                                CallArgument::Raw(bytes)
+                                            } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) {
+                                                CallArgument::Raw(minb)
+                                            } else {
+                                                CallArgument::Raw(vec![])
+                                            }
+                                        }
                                         other => other,
                                     }
-                                } else { prev_or_raw }
-                            },
+                                } else {
+                                    prev_or_raw
+                                }
+                            }
                             // other value types: if Raw empty, fill minimal BCS
                             (Some(t), CallArgument::Raw(bytes)) => {
                                 // For value types, if provided Raw length mismatches expected fixed-size,
                                 // replace with minimal correct BCS; otherwise keep.
-                                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, &cm, t, &call.ty_args) {
+                                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, &cm, t, &call.ty_args)
+                                {
                                     if let Some(expected) = expected_fixed_len_bytes(&tag) {
                                         if bytes.len() != expected {
                                             CallArgument::Raw(minimal_bcs_for_typetag(&tag).unwrap_or_else(|| vec![]))
                                         } else {
-                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                            if !bytes.is_empty() {
+                                                CallArgument::Raw(bytes)
+                                            } else if let Some(minb) =
+                                                minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args)
+                                            {
+                                                CallArgument::Raw(minb)
+                                            } else {
+                                                CallArgument::Raw(vec![])
+                                            }
                                         }
                                     } else {
-                                        if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                        if !bytes.is_empty() {
+                                            CallArgument::Raw(bytes)
+                                        } else if let Some(minb) =
+                                            minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args)
+                                        {
+                                            CallArgument::Raw(minb)
+                                        } else {
+                                            CallArgument::Raw(vec![])
+                                        }
                                     }
                                 } else {
-                                    if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                    if !bytes.is_empty() {
+                                        CallArgument::Raw(bytes)
+                                    } else if let Some(minb) =
+                                        minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args)
+                                    {
+                                        CallArgument::Raw(minb)
+                                    } else {
+                                        CallArgument::Raw(vec![])
+                                    }
                                 }
                             }
                             // keep as is
@@ -169,24 +223,34 @@ fn type_tag_from_signature(
         ST::Struct(idx) => {
             let st = module.struct_handle_at(*idx);
             let mh = module.module_handle_at(st.module);
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module.address_identifier_at(mh.address),
-                module: module.identifier_at(mh.name).to_owned(),
-                name: module.identifier_at(st.name).to_owned(),
-                type_args: vec![],
-            })))
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module.address_identifier_at(mh.address),
+                    module: module.identifier_at(mh.name).to_owned(),
+                    name: module.identifier_at(st.name).to_owned(),
+                    type_args: vec![],
+                },
+            )))
         }
         ST::StructInstantiation(idx, toks) => {
             let st = module.struct_handle_at(*idx);
             let mh = module.module_handle_at(st.module);
             let mut targs = Vec::with_capacity(toks.len());
-            for t in toks { if let Some(tag) = type_tag_from_signature(module, t, ty_args) { targs.push(tag) } else { return None } }
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module.address_identifier_at(mh.address),
-                module: module.identifier_at(mh.name).to_owned(),
-                name: module.identifier_at(st.name).to_owned(),
-                type_args: targs,
-            })))
+            for t in toks {
+                if let Some(tag) = type_tag_from_signature(module, t, ty_args) {
+                    targs.push(tag)
+                } else {
+                    return None;
+                }
+            }
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module.address_identifier_at(mh.address),
+                    module: module.identifier_at(mh.name).to_owned(),
+                    name: module.identifier_at(st.name).to_owned(),
+                    type_args: targs,
+                },
+            )))
         }
         ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
         ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
@@ -274,7 +338,11 @@ fn minimal_move_value_for_token_with_storage<S: ModuleStorage>(
         ST::Address => Some(MoveValue::Address(FUZZER_SENDER)),
         ST::Signer => Some(MoveValue::Signer(FUZZER_SENDER)),
         ST::Vector(inner) => {
-            if matches!(**inner, ST::U8) { Some(MoveValue::vector_u8(vec![])) } else { Some(MoveValue::Vector(vec![])) }
+            if matches!(**inner, ST::U8) {
+                Some(MoveValue::vector_u8(vec![]))
+            } else {
+                Some(MoveValue::Vector(vec![]))
+            }
         }
         ST::Struct(idx) => {
             let sh = module_ctx.struct_handle_at(*idx);
@@ -292,13 +360,18 @@ fn minimal_move_value_for_token_with_storage<S: ModuleStorage>(
             let struct_ident = module_ctx.identifier_at(sh.name).to_owned();
             let mut type_args: Vec<TypeTag> = Vec::with_capacity(toks.len());
             for t in toks {
-                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) { type_args.push(tag) } else { return None }
+                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) {
+                    type_args.push(tag)
+                } else {
+                    return None;
+                }
             }
             minimal_move_value_for_struct(storage, &addr, &module_ident, &struct_ident, &type_args)
         }
-        ST::TypeParameter(i) => {
-            func_ty_args.get(*i as usize).cloned().and_then(|t| minimal_move_value_for_typetag_full(storage, &t))
-        }
+        ST::TypeParameter(i) => func_ty_args
+            .get(*i as usize)
+            .cloned()
+            .and_then(|t| minimal_move_value_for_typetag_full(storage, &t)),
         ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
     }
 }
@@ -320,28 +393,39 @@ fn resolve_token_to_typetag_with_storage<S: ModuleStorage>(
         ST::U256 => Some(TypeTag::U256),
         ST::Address => Some(TypeTag::Address),
         ST::Signer => Some(TypeTag::Signer),
-        ST::Vector(inner) => resolve_token_to_typetag_with_storage(storage, module_ctx, inner, func_ty_args).map(|t| TypeTag::Vector(Box::new(t))),
+        ST::Vector(inner) => resolve_token_to_typetag_with_storage(storage, module_ctx, inner, func_ty_args)
+            .map(|t| TypeTag::Vector(Box::new(t))),
         ST::Struct(idx) => {
             let sh = module_ctx.struct_handle_at(*idx);
             let mh = module_ctx.module_handle_at(sh.module);
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module_ctx.address_identifier_at(mh.address),
-                module: module_ctx.identifier_at(mh.name).to_owned(),
-                name: module_ctx.identifier_at(sh.name).to_owned(),
-                type_args: vec![],
-            })))
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module_ctx.address_identifier_at(mh.address),
+                    module: module_ctx.identifier_at(mh.name).to_owned(),
+                    name: module_ctx.identifier_at(sh.name).to_owned(),
+                    type_args: vec![],
+                },
+            )))
         }
         ST::StructInstantiation(idx, toks) => {
             let sh = module_ctx.struct_handle_at(*idx);
             let mh = module_ctx.module_handle_at(sh.module);
             let mut targs = Vec::with_capacity(toks.len());
-            for t in toks { if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) { targs.push(tag) } else { return None } }
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module_ctx.address_identifier_at(mh.address),
-                module: module_ctx.identifier_at(mh.name).to_owned(),
-                name: module_ctx.identifier_at(sh.name).to_owned(),
-                type_args: targs,
-            })))
+            for t in toks {
+                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) {
+                    targs.push(tag)
+                } else {
+                    return None;
+                }
+            }
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module_ctx.address_identifier_at(mh.address),
+                    module: module_ctx.identifier_at(mh.name).to_owned(),
+                    name: module_ctx.identifier_at(sh.name).to_owned(),
+                    type_args: targs,
+                },
+            )))
         }
         ST::TypeParameter(i) => func_ty_args.get(*i as usize).cloned(),
         ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
@@ -360,16 +444,26 @@ fn minimal_move_value_for_typetag_full<S: ModuleStorage>(storage: &S, ty: &TypeT
         TypeTag::Address => Some(MoveValue::Address(FUZZER_SENDER)),
         TypeTag::Signer => Some(MoveValue::Signer(FUZZER_SENDER)),
         TypeTag::Vector(inner) => {
-            if matches!(**inner, TypeTag::U8) { Some(MoveValue::vector_u8(vec![])) } else { Some(MoveValue::Vector(vec![])) }
+            if matches!(**inner, TypeTag::U8) {
+                Some(MoveValue::vector_u8(vec![]))
+            } else {
+                Some(MoveValue::Vector(vec![]))
+            }
         }
         TypeTag::Struct(st) => minimal_move_value_for_struct_tag(storage, st),
         TypeTag::Function(_) => None,
     }
 }
 
-fn minimal_move_value_for_struct_tag<S: ModuleStorage>(storage: &S, st: &aptos_move_core_types::language_storage::StructTag) -> Option<MoveValue> {
+fn minimal_move_value_for_struct_tag<S: ModuleStorage>(
+    storage: &S,
+    st: &aptos_move_core_types::language_storage::StructTag,
+) -> Option<MoveValue> {
     let module_id = ModuleId::new(st.address, st.module.clone());
-    let cm = storage.unmetered_get_deserialized_module(module_id.address(), module_id.name()).ok().flatten()?;
+    let cm = storage
+        .unmetered_get_deserialized_module(module_id.address(), module_id.name())
+        .ok()
+        .flatten()?;
     minimal_move_value_for_struct(storage, module_id.address(), module_id.name(), &st.name, &st.type_args)
 }
 
@@ -380,7 +474,10 @@ fn minimal_move_value_for_struct<S: ModuleStorage>(
     struct_name: &aptos_move_core_types::identifier::Identifier,
     type_args: &[TypeTag],
 ) -> Option<MoveValue> {
-    let cm = storage.unmetered_get_deserialized_module(module_addr, module_name).ok().flatten()?;
+    let cm = storage
+        .unmetered_get_deserialized_module(module_addr, module_name)
+        .ok()
+        .flatten()?;
     // find struct definition by name
     for def in cm.struct_defs() {
         let sh = cm.struct_handle_at(def.struct_handle);
@@ -393,8 +490,14 @@ fn minimal_move_value_for_struct<S: ModuleStorage>(
                     for f in fields {
                         let ftok = &f.signature.0;
                         if let Some(tag) = struct_field_token_to_typetag(&cm, ftok, type_args) {
-                            if let Some(mv) = minimal_move_value_for_typetag_full(storage, &tag) { vals.push(mv); } else { return None }
-                        } else { return None }
+                            if let Some(mv) = minimal_move_value_for_typetag_full(storage, &tag) {
+                                vals.push(mv);
+                            } else {
+                                return None;
+                            }
+                        } else {
+                            return None;
+                        }
                     }
                     return Some(MoveValue::Struct(MoveStruct::Runtime(vals)));
                 }
@@ -424,28 +527,40 @@ fn struct_field_token_to_typetag(
         ST::U256 => Some(TypeTag::U256),
         ST::Address => Some(TypeTag::Address),
         ST::Signer => Some(TypeTag::Signer),
-        ST::Vector(inner) => struct_field_token_to_typetag(module, inner, struct_type_args).map(|t| TypeTag::Vector(Box::new(t))),
+        ST::Vector(inner) => {
+            struct_field_token_to_typetag(module, inner, struct_type_args).map(|t| TypeTag::Vector(Box::new(t)))
+        }
         ST::Struct(idx) => {
             let sh = module.struct_handle_at(*idx);
             let mh = module.module_handle_at(sh.module);
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module.address_identifier_at(mh.address),
-                module: module.identifier_at(mh.name).to_owned(),
-                name: module.identifier_at(sh.name).to_owned(),
-                type_args: vec![],
-            })))
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module.address_identifier_at(mh.address),
+                    module: module.identifier_at(mh.name).to_owned(),
+                    name: module.identifier_at(sh.name).to_owned(),
+                    type_args: vec![],
+                },
+            )))
         }
         ST::StructInstantiation(idx, toks) => {
             let sh = module.struct_handle_at(*idx);
             let mh = module.module_handle_at(sh.module);
             let mut targs = Vec::with_capacity(toks.len());
-            for t in toks { if let Some(tag) = struct_field_token_to_typetag(module, t, struct_type_args) { targs.push(tag) } else { return None } }
-            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
-                address: *module.address_identifier_at(mh.address),
-                module: module.identifier_at(mh.name).to_owned(),
-                name: module.identifier_at(sh.name).to_owned(),
-                type_args: targs,
-            })))
+            for t in toks {
+                if let Some(tag) = struct_field_token_to_typetag(module, t, struct_type_args) {
+                    targs.push(tag)
+                } else {
+                    return None;
+                }
+            }
+            Some(TypeTag::Struct(Box::new(
+                aptos_move_core_types::language_storage::StructTag {
+                    address: *module.address_identifier_at(mh.address),
+                    module: module.identifier_at(mh.name).to_owned(),
+                    name: module.identifier_at(sh.name).to_owned(),
+                    type_args: targs,
+                },
+            )))
         }
         ST::TypeParameter(i) => struct_type_args.get(*i as usize).cloned(),
         ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -4,6 +4,13 @@ use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
 use libafl::inputs::Input;
 use serde::{Deserialize, Serialize};
 
+// new imports for shaping
+use aptos_move_binary_format::access::ModuleAccess;
+use aptos_move_vm_runtime::ModuleStorage;
+use aptos_vm::aptos_vm::FUZZER_SENDER;
+use aptos_move_core_types::value::{MoveStruct, MoveValue};
+use aptos_move_core_types::identifier::IdentStr;
+
 /// Represents a single function call with batched-call compatible arguments.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct Call {
@@ -44,11 +51,372 @@ impl AptosFuzzerInput {
         self.calls.push(call);
     }
 
-    pub fn len(&self) -> usize {
-        self.calls.len()
-    }
+    pub fn len(&self) -> usize { self.calls.len() }
+    pub fn is_empty(&self) -> bool { self.calls.is_empty() }
 
-    pub fn is_empty(&self) -> bool {
-        self.calls.is_empty()
+    /// Return a copy of `calls` with arguments shaped to minimal deserializable BCS
+    /// using module metadata from the provided storage.
+    pub fn shaped_calls<S: ModuleStorage>(&self, storage: &S) -> Vec<Call> {
+        let mut out = Vec::with_capacity(self.calls.len());
+        // Note: &T/&mut T borrowing from previous results is handled during composing in executor
+        for call in &self.calls {
+            let mut shaped_call = call.clone();
+            if let Ok(Some(cm)) = storage.unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name()) {
+                // locate function handle
+                let mut params: Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> = None;
+                let mut returns: Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> = None;
+                for def in cm.function_defs() {
+                    let h = cm.function_handle_at(def.function);
+                    if cm.identifier_at(h.name) == call.function_name.as_ident_str() {
+                        params = Some(cm.signature_at(h.parameters).0.clone());
+                        returns = Some(cm.signature_at(h.return_).0.clone());
+                        break;
+                    }
+                }
+                if let Some(param_toks) = params {
+                    let mut new_args = Vec::with_capacity(shaped_call.args.len());
+                    for (idx, arg) in shaped_call.args.iter().cloned().enumerate() {
+                        let tok_opt = param_toks.get(idx);
+                        let arg = match (tok_opt, arg) {
+                            // &signer / &mut signer
+                            (Some(t), _) if is_signer_reference(t) => CallArgument::Signer(0),
+                            // value Signer
+                            (Some(aptos_move_binary_format::file_format::SignatureToken::Signer), _) => CallArgument::Signer(0),
+                            // general &T / &mut T: leave Raw shaping; borrowing is composed later
+                            (Some(aptos_move_binary_format::file_format::SignatureToken::Reference(inner)), prev_or_raw) => {
+                                if let Some(base_tag) = type_tag_from_signature(&cm, inner, &call.ty_args) {
+                                    match prev_or_raw {
+                                        CallArgument::Raw(bytes) => {
+                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                        },
+                                        other => other,
+                                    }
+                                } else { prev_or_raw }
+                            },
+                            (Some(aptos_move_binary_format::file_format::SignatureToken::MutableReference(inner)), prev_or_raw) => {
+                                if let Some(base_tag) = type_tag_from_signature(&cm, inner, &call.ty_args) {
+                                    match prev_or_raw {
+                                        CallArgument::Raw(bytes) => {
+                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_typetag(&base_tag) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                        },
+                                        other => other,
+                                    }
+                                } else { prev_or_raw }
+                            },
+                            // other value types: if Raw empty, fill minimal BCS
+                            (Some(t), CallArgument::Raw(bytes)) => {
+                                if !bytes.is_empty() {
+                                    CallArgument::Raw(bytes)
+                                } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                            }
+                            // keep as is
+                            (_, other) => other,
+                        };
+                        new_args.push(arg);
+                    }
+                    shaped_call.args = new_args;
+                }
+                // push shaped call, record its index
+                out.push(shaped_call);
+                let cur_idx = (out.len() - 1) as u16;
+                continue;
+            }
+            // no module info, just push
+            out.push(shaped_call);
+        }
+        out
+    }
+}
+
+// --- helpers ---
+fn is_signer_reference(tok: &aptos_move_binary_format::file_format::SignatureToken) -> bool {
+    use aptos_move_binary_format::file_format::SignatureToken as ST;
+    match tok {
+        ST::Reference(inner) | ST::MutableReference(inner) => matches!(**inner, ST::Signer),
+        _ => false,
+    }
+}
+
+fn type_tag_from_signature(
+    module: &aptos_move_binary_format::CompiledModule,
+    tok: &aptos_move_binary_format::file_format::SignatureToken,
+    ty_args: &[TypeTag],
+) -> Option<TypeTag> {
+    use aptos_move_binary_format::file_format::SignatureToken as ST;
+    match tok {
+        ST::Bool => Some(TypeTag::Bool),
+        ST::U8 => Some(TypeTag::U8),
+        ST::U16 => Some(TypeTag::U16),
+        ST::U32 => Some(TypeTag::U32),
+        ST::U64 => Some(TypeTag::U64),
+        ST::U128 => Some(TypeTag::U128),
+        ST::U256 => Some(TypeTag::U256),
+        ST::Address => Some(TypeTag::Address),
+        ST::Signer => Some(TypeTag::Signer),
+        ST::Vector(inner) => type_tag_from_signature(module, inner, ty_args).map(|t| TypeTag::Vector(Box::new(t))),
+        ST::Struct(idx) => {
+            let st = module.struct_handle_at(*idx);
+            let mh = module.module_handle_at(st.module);
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module.address_identifier_at(mh.address),
+                module: module.identifier_at(mh.name).to_owned(),
+                name: module.identifier_at(st.name).to_owned(),
+                type_args: vec![],
+            })))
+        }
+        ST::StructInstantiation(idx, toks) => {
+            let st = module.struct_handle_at(*idx);
+            let mh = module.module_handle_at(st.module);
+            let mut targs = Vec::with_capacity(toks.len());
+            for t in toks { if let Some(tag) = type_tag_from_signature(module, t, ty_args) { targs.push(tag) } else { return None } }
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module.address_identifier_at(mh.address),
+                module: module.identifier_at(mh.name).to_owned(),
+                name: module.identifier_at(st.name).to_owned(),
+                type_args: targs,
+            })))
+        }
+        ST::TypeParameter(i) => ty_args.get(*i as usize).cloned(),
+        ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
+    }
+}
+
+fn minimal_bcs_for_typetag(ty: &TypeTag) -> Option<Vec<u8>> {
+    use aptos_move_core_types::value::MoveValue;
+    match ty {
+        TypeTag::Bool => MoveValue::Bool(false).simple_serialize(),
+        TypeTag::U8 => MoveValue::U8(0).simple_serialize(),
+        TypeTag::U16 => MoveValue::U16(0).simple_serialize(),
+        TypeTag::U32 => MoveValue::U32(0).simple_serialize(),
+        TypeTag::U64 => MoveValue::U64(0).simple_serialize(),
+        TypeTag::U128 => MoveValue::U128(0).simple_serialize(),
+        TypeTag::U256 => MoveValue::U256(0u128.into()).simple_serialize(),
+        TypeTag::Address => MoveValue::Address(FUZZER_SENDER).simple_serialize(),
+        TypeTag::Signer => MoveValue::Signer(FUZZER_SENDER).simple_serialize(),
+        TypeTag::Vector(inner) => {
+            if matches!(**inner, TypeTag::U8) {
+                MoveValue::vector_u8(vec![]).simple_serialize()
+            } else {
+                MoveValue::Vector(vec![]).simple_serialize()
+            }
+        }
+        TypeTag::Struct(s) => {
+            let module = s.module.as_ident_str();
+            let name = s.name.as_ident_str();
+            if module.as_str() == "string" && name.as_str() == "String" {
+                return MoveValue::vector_u8(vec![]).simple_serialize();
+            }
+            if module.as_str() == "option" && name.as_str() == "Option" {
+                return MoveValue::Vector(vec![]).simple_serialize();
+            }
+            None
+        }
+        TypeTag::Function(_) => None,
+    }
+}
+
+fn minimal_bcs_for_token_with_storage<S: ModuleStorage>(
+    storage: &S,
+    module_ctx: &aptos_move_binary_format::CompiledModule,
+    tok: &aptos_move_binary_format::file_format::SignatureToken,
+    func_ty_args: &[TypeTag],
+) -> Option<Vec<u8>> {
+    minimal_move_value_for_token_with_storage(storage, module_ctx, tok, func_ty_args)
+        .and_then(|mv| mv.simple_serialize())
+}
+
+fn minimal_move_value_for_token_with_storage<S: ModuleStorage>(
+    storage: &S,
+    module_ctx: &aptos_move_binary_format::CompiledModule,
+    tok: &aptos_move_binary_format::file_format::SignatureToken,
+    func_ty_args: &[TypeTag],
+) -> Option<MoveValue> {
+    use aptos_move_binary_format::file_format::SignatureToken as ST;
+    match tok {
+        ST::Bool => Some(MoveValue::Bool(false)),
+        ST::U8 => Some(MoveValue::U8(0)),
+        ST::U16 => Some(MoveValue::U16(0)),
+        ST::U32 => Some(MoveValue::U32(0)),
+        ST::U64 => Some(MoveValue::U64(0)),
+        ST::U128 => Some(MoveValue::U128(0)),
+        ST::U256 => Some(MoveValue::U256(0u128.into())),
+        ST::Address => Some(MoveValue::Address(FUZZER_SENDER)),
+        ST::Signer => Some(MoveValue::Signer(FUZZER_SENDER)),
+        ST::Vector(inner) => {
+            if matches!(**inner, ST::U8) { Some(MoveValue::vector_u8(vec![])) } else { Some(MoveValue::Vector(vec![])) }
+        }
+        ST::Struct(idx) => {
+            let sh = module_ctx.struct_handle_at(*idx);
+            let mh = module_ctx.module_handle_at(sh.module);
+            let addr = *module_ctx.address_identifier_at(mh.address);
+            let module_ident = module_ctx.identifier_at(mh.name).to_owned();
+            let struct_ident = module_ctx.identifier_at(sh.name).to_owned();
+            minimal_move_value_for_struct(storage, &addr, &module_ident, &struct_ident, &[])
+        }
+        ST::StructInstantiation(idx, toks) => {
+            let sh = module_ctx.struct_handle_at(*idx);
+            let mh = module_ctx.module_handle_at(sh.module);
+            let addr = *module_ctx.address_identifier_at(mh.address);
+            let module_ident = module_ctx.identifier_at(mh.name).to_owned();
+            let struct_ident = module_ctx.identifier_at(sh.name).to_owned();
+            let mut type_args: Vec<TypeTag> = Vec::with_capacity(toks.len());
+            for t in toks {
+                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) { type_args.push(tag) } else { return None }
+            }
+            minimal_move_value_for_struct(storage, &addr, &module_ident, &struct_ident, &type_args)
+        }
+        ST::TypeParameter(i) => {
+            func_ty_args.get(*i as usize).cloned().and_then(|t| minimal_move_value_for_typetag_full(storage, &t))
+        }
+        ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
+    }
+}
+
+fn resolve_token_to_typetag_with_storage<S: ModuleStorage>(
+    storage: &S,
+    module_ctx: &aptos_move_binary_format::CompiledModule,
+    tok: &aptos_move_binary_format::file_format::SignatureToken,
+    func_ty_args: &[TypeTag],
+) -> Option<TypeTag> {
+    use aptos_move_binary_format::file_format::SignatureToken as ST;
+    match tok {
+        ST::Bool => Some(TypeTag::Bool),
+        ST::U8 => Some(TypeTag::U8),
+        ST::U16 => Some(TypeTag::U16),
+        ST::U32 => Some(TypeTag::U32),
+        ST::U64 => Some(TypeTag::U64),
+        ST::U128 => Some(TypeTag::U128),
+        ST::U256 => Some(TypeTag::U256),
+        ST::Address => Some(TypeTag::Address),
+        ST::Signer => Some(TypeTag::Signer),
+        ST::Vector(inner) => resolve_token_to_typetag_with_storage(storage, module_ctx, inner, func_ty_args).map(|t| TypeTag::Vector(Box::new(t))),
+        ST::Struct(idx) => {
+            let sh = module_ctx.struct_handle_at(*idx);
+            let mh = module_ctx.module_handle_at(sh.module);
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module_ctx.address_identifier_at(mh.address),
+                module: module_ctx.identifier_at(mh.name).to_owned(),
+                name: module_ctx.identifier_at(sh.name).to_owned(),
+                type_args: vec![],
+            })))
+        }
+        ST::StructInstantiation(idx, toks) => {
+            let sh = module_ctx.struct_handle_at(*idx);
+            let mh = module_ctx.module_handle_at(sh.module);
+            let mut targs = Vec::with_capacity(toks.len());
+            for t in toks { if let Some(tag) = resolve_token_to_typetag_with_storage(storage, module_ctx, t, func_ty_args) { targs.push(tag) } else { return None } }
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module_ctx.address_identifier_at(mh.address),
+                module: module_ctx.identifier_at(mh.name).to_owned(),
+                name: module_ctx.identifier_at(sh.name).to_owned(),
+                type_args: targs,
+            })))
+        }
+        ST::TypeParameter(i) => func_ty_args.get(*i as usize).cloned(),
+        ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
+    }
+}
+
+fn minimal_move_value_for_typetag_full<S: ModuleStorage>(storage: &S, ty: &TypeTag) -> Option<MoveValue> {
+    match ty {
+        TypeTag::Bool => Some(MoveValue::Bool(false)),
+        TypeTag::U8 => Some(MoveValue::U8(0)),
+        TypeTag::U16 => Some(MoveValue::U16(0)),
+        TypeTag::U32 => Some(MoveValue::U32(0)),
+        TypeTag::U64 => Some(MoveValue::U64(0)),
+        TypeTag::U128 => Some(MoveValue::U128(0)),
+        TypeTag::U256 => Some(MoveValue::U256(0u128.into())),
+        TypeTag::Address => Some(MoveValue::Address(FUZZER_SENDER)),
+        TypeTag::Signer => Some(MoveValue::Signer(FUZZER_SENDER)),
+        TypeTag::Vector(inner) => {
+            if matches!(**inner, TypeTag::U8) { Some(MoveValue::vector_u8(vec![])) } else { Some(MoveValue::Vector(vec![])) }
+        }
+        TypeTag::Struct(st) => minimal_move_value_for_struct_tag(storage, st),
+        TypeTag::Function(_) => None,
+    }
+}
+
+fn minimal_move_value_for_struct_tag<S: ModuleStorage>(storage: &S, st: &aptos_move_core_types::language_storage::StructTag) -> Option<MoveValue> {
+    let module_id = ModuleId::new(st.address, st.module.clone());
+    let cm = storage.unmetered_get_deserialized_module(module_id.address(), module_id.name()).ok().flatten()?;
+    minimal_move_value_for_struct(storage, module_id.address(), module_id.name(), &st.name, &st.type_args)
+}
+
+fn minimal_move_value_for_struct<S: ModuleStorage>(
+    storage: &S,
+    module_addr: &aptos_move_core_types::account_address::AccountAddress,
+    module_name: &IdentStr,
+    struct_name: &aptos_move_core_types::identifier::Identifier,
+    type_args: &[TypeTag],
+) -> Option<MoveValue> {
+    let cm = storage.unmetered_get_deserialized_module(module_addr, module_name).ok().flatten()?;
+    // find struct definition by name
+    for def in cm.struct_defs() {
+        let sh = cm.struct_handle_at(def.struct_handle);
+        if cm.identifier_at(sh.name) == struct_name.as_ident_str() {
+            use aptos_move_binary_format::file_format::StructFieldInformation as SFI;
+            match &def.field_information {
+                SFI::Native => return None,
+                SFI::Declared(fields) => {
+                    let mut vals: Vec<MoveValue> = Vec::with_capacity(fields.len());
+                    for f in fields {
+                        let ftok = &f.signature.0;
+                        if let Some(tag) = struct_field_token_to_typetag(&cm, ftok, type_args) {
+                            if let Some(mv) = minimal_move_value_for_typetag_full(storage, &tag) { vals.push(mv); } else { return None }
+                        } else { return None }
+                    }
+                    return Some(MoveValue::Struct(MoveStruct::Runtime(vals)));
+                }
+                SFI::DeclaredVariants(_variants) => {
+                    // TODO: enum support - not yet implemented
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
+fn struct_field_token_to_typetag(
+    module: &aptos_move_binary_format::CompiledModule,
+    tok: &aptos_move_binary_format::file_format::SignatureToken,
+    struct_type_args: &[TypeTag],
+) -> Option<TypeTag> {
+    use aptos_move_binary_format::file_format::SignatureToken as ST;
+    match tok {
+        ST::Bool => Some(TypeTag::Bool),
+        ST::U8 => Some(TypeTag::U8),
+        ST::U16 => Some(TypeTag::U16),
+        ST::U32 => Some(TypeTag::U32),
+        ST::U64 => Some(TypeTag::U64),
+        ST::U128 => Some(TypeTag::U128),
+        ST::U256 => Some(TypeTag::U256),
+        ST::Address => Some(TypeTag::Address),
+        ST::Signer => Some(TypeTag::Signer),
+        ST::Vector(inner) => struct_field_token_to_typetag(module, inner, struct_type_args).map(|t| TypeTag::Vector(Box::new(t))),
+        ST::Struct(idx) => {
+            let sh = module.struct_handle_at(*idx);
+            let mh = module.module_handle_at(sh.module);
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module.address_identifier_at(mh.address),
+                module: module.identifier_at(mh.name).to_owned(),
+                name: module.identifier_at(sh.name).to_owned(),
+                type_args: vec![],
+            })))
+        }
+        ST::StructInstantiation(idx, toks) => {
+            let sh = module.struct_handle_at(*idx);
+            let mh = module.module_handle_at(sh.module);
+            let mut targs = Vec::with_capacity(toks.len());
+            for t in toks { if let Some(tag) = struct_field_token_to_typetag(module, t, struct_type_args) { targs.push(tag) } else { return None } }
+            Some(TypeTag::Struct(Box::new(aptos_move_core_types::language_storage::StructTag {
+                address: *module.address_identifier_at(mh.address),
+                module: module.identifier_at(mh.name).to_owned(),
+                name: module.identifier_at(sh.name).to_owned(),
+                type_args: targs,
+            })))
+        }
+        ST::TypeParameter(i) => struct_type_args.get(*i as usize).cloned(),
+        ST::Reference(_) | ST::MutableReference(_) | ST::Function(_, _, _) => None,
     }
 }

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -105,9 +105,21 @@ impl AptosFuzzerInput {
                             },
                             // other value types: if Raw empty, fill minimal BCS
                             (Some(t), CallArgument::Raw(bytes)) => {
-                                if !bytes.is_empty() {
-                                    CallArgument::Raw(bytes)
-                                } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                // For value types, if provided Raw length mismatches expected fixed-size,
+                                // replace with minimal correct BCS; otherwise keep.
+                                if let Some(tag) = resolve_token_to_typetag_with_storage(storage, &cm, t, &call.ty_args) {
+                                    if let Some(expected) = expected_fixed_len_bytes(&tag) {
+                                        if bytes.len() != expected {
+                                            CallArgument::Raw(minimal_bcs_for_typetag(&tag).unwrap_or_else(|| vec![]))
+                                        } else {
+                                            if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                        }
+                                    } else {
+                                        if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                    }
+                                } else {
+                                    if !bytes.is_empty() { CallArgument::Raw(bytes) } else if let Some(minb) = minimal_bcs_for_token_with_storage(storage, &cm, t, &call.ty_args) { CallArgument::Raw(minb) } else { CallArgument::Raw(vec![]) }
+                                }
                             }
                             // keep as is
                             (_, other) => other,
@@ -211,6 +223,25 @@ fn minimal_bcs_for_typetag(ty: &TypeTag) -> Option<Vec<u8>> {
             }
             None
         }
+        TypeTag::Function(_) => None,
+    }
+}
+
+fn expected_fixed_len_bytes(tag: &TypeTag) -> Option<usize> {
+    match tag {
+        TypeTag::Bool => Some(1),
+        TypeTag::U8 => Some(1),
+        TypeTag::U16 => Some(2),
+        TypeTag::U32 => Some(4),
+        TypeTag::U64 => Some(8),
+        TypeTag::U128 => Some(16),
+        TypeTag::U256 => Some(32),
+        // Aptos addresses are 32 bytes
+        TypeTag::Address => Some(32),
+        // variable size below
+        TypeTag::Signer => None,
+        TypeTag::Vector(_) => None,
+        TypeTag::Struct(_) => None,
         TypeTag::Function(_) => None,
     }
 }

--- a/crates/aptos-fuzzer/src/input.rs
+++ b/crates/aptos-fuzzer/src/input.rs
@@ -1,24 +1,69 @@
+use aptos_move_core_types::identifier::Identifier;
+use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
 use aptos_types::transaction::EntryFunction;
 use libafl::inputs::Input;
 use serde::{Deserialize, Serialize};
 
+/// Represents a single function call with all necessary parameters.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct FuncCall {
+    pub module_id: ModuleId,
+    pub function_name: Identifier,
+    pub ty_args: Vec<TypeTag>,
+    pub bcs_args: Vec<Vec<u8>>,
+}
+
+impl FuncCall {
+    pub fn new(
+        module_id: ModuleId,
+        function_name: Identifier,
+        ty_args: Vec<TypeTag>,
+        bcs_args: Vec<Vec<u8>>,
+    ) -> Self {
+        Self {
+            module_id,
+            function_name,
+            ty_args,
+            bcs_args,
+        }
+    }
+    
+    /// Convert to EntryFunction for execution
+    pub fn to_entry_function(&self) -> EntryFunction {
+        EntryFunction::new(
+            self.module_id.clone(),
+            self.function_name.clone(),
+            self.ty_args.clone(),
+            self.bcs_args.clone(),
+        )
+    }
+}
+
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct AptosFuzzerInput {
-    pub calls: Vec<EntryFunction>,
+    pub calls: Vec<FuncCall>,
 }
 
 impl Input for AptosFuzzerInput {}
 
 impl AptosFuzzerInput {
-    pub fn new(call: EntryFunction) -> Self {
+    pub fn new(call: FuncCall) -> Self {
         Self { calls: vec![call] }
     }
     
-    pub fn from_calls(calls: Vec<EntryFunction>) -> Self {
+    pub fn from_calls(calls: Vec<FuncCall>) -> Self {
         Self { calls }
     }
     
-    pub fn push(&mut self, call: EntryFunction) {
+    pub fn from_entry_function(entry_func: EntryFunction) -> Self {
+        let (module_id, function_name, ty_args, bcs_args) = entry_func.into_inner();
+        Self {
+            calls: vec![FuncCall::new(module_id, function_name, ty_args, bcs_args)],
+        }
+    }
+    
+    pub fn push(&mut self, call: FuncCall) {
         self.calls.push(call);
     }
     

--- a/crates/aptos-fuzzer/src/lib.rs
+++ b/crates/aptos-fuzzer/src/lib.rs
@@ -9,7 +9,7 @@ pub mod state;
 pub use aptos_vm::aptos_vm::FUZZER_SENDER;
 pub use executor::aptos_move_executor::AptosMoveExecutor;
 pub use feedback::{AbortCodeObjective, ShiftOverflowObjective};
-pub use input::AptosFuzzerInput;
+pub use input::{AptosFuzzerInput, FuncCall};
 pub use mir::Chain;
 pub use mutator::AptosFuzzerMutator;
 pub use state::{AptosFuzzerState, MAP_SIZE};

--- a/crates/aptos-fuzzer/src/lib.rs
+++ b/crates/aptos-fuzzer/src/lib.rs
@@ -1,12 +1,15 @@
 pub mod executor;
 pub mod feedback;
 pub mod input;
+pub mod mir;
 pub mod mutator;
 pub mod observers;
 pub mod state;
 
+pub use aptos_vm::aptos_vm::FUZZER_SENDER;
 pub use executor::aptos_move_executor::AptosMoveExecutor;
 pub use feedback::{AbortCodeObjective, ShiftOverflowObjective};
 pub use input::AptosFuzzerInput;
+pub use mir::Chain;
 pub use mutator::AptosFuzzerMutator;
 pub use state::{AptosFuzzerState, MAP_SIZE};

--- a/crates/aptos-fuzzer/src/lib.rs
+++ b/crates/aptos-fuzzer/src/lib.rs
@@ -9,7 +9,7 @@ pub mod state;
 pub use aptos_vm::aptos_vm::FUZZER_SENDER;
 pub use executor::aptos_move_executor::AptosMoveExecutor;
 pub use feedback::{AbortCodeObjective, ShiftOverflowObjective};
-pub use input::{AptosFuzzerInput, FuncCall};
+pub use input::{AptosFuzzerInput, Call};
 pub use mir::Chain;
 pub use mutator::AptosFuzzerMutator;
 pub use state::{AptosFuzzerState, MAP_SIZE};

--- a/crates/aptos-fuzzer/src/mir.rs
+++ b/crates/aptos-fuzzer/src/mir.rs
@@ -721,25 +721,26 @@ pub fn resloc_simple(struct_name: &str, addr: AddrExpr) -> ResLoc {
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::ModuleId;
-use aptos_types::transaction::EntryFunction;
 use aptos_vm::aptos_vm::FUZZER_SENDER;
 use bcs;
 
+use crate::input::FuncCall;
+
 impl Chain {
-    /// Convert Chain calls to Input calls
-    pub fn to_entry_functions(&self) -> Result<Vec<EntryFunction>, String> {
-        let mut functions = Vec::new();
+    /// Convert Chain calls to FuncCall inputs
+    pub fn to_func_calls(&self) -> Result<Vec<FuncCall>, String> {
+        let mut func_calls = Vec::new();
         
         for call in &self.calls {
-            let entry_fn = call_to_entry_function(call)?;
-            functions.push(entry_fn);
+            let func_call = call_to_func_call(call)?;
+            func_calls.push(func_call);
         }
         
-        Ok(functions)
+        Ok(func_calls)
     }
 }
 
-fn call_to_entry_function(call: &Call) -> Result<EntryFunction, String> {
+fn call_to_func_call(call: &Call) -> Result<FuncCall, String> {
     // Parse module address
     let addr_bytes = hex::decode(&call.module_addr)
         .map_err(|e| format!("Invalid module address: {}", e))?;
@@ -786,8 +787,7 @@ fn call_to_entry_function(call: &Call) -> Result<EntryFunction, String> {
         }
     }
     
-    let entry_fn = EntryFunction::new(module_id, function_name, ty_args, bcs_args);
-    Ok(entry_fn)
+    Ok(FuncCall::new(module_id, function_name, ty_args, bcs_args))
 }
 
 fn generate_value_for_type(ty: &TypeTagLite) -> Result<Vec<u8>, String> {

--- a/crates/aptos-fuzzer/src/mir.rs
+++ b/crates/aptos-fuzzer/src/mir.rs
@@ -1,11 +1,13 @@
 // Suggested MIR Rust definitions for crates/aptos-fuzzer/src/mir/ir.rs
 // Designed to be a compact, expressive IR for Move interactions (MIR)
-// Focus: enums, structs, and traits representing types, values, resource locations,
-// facts (preconditions), effects (postconditions), calls, and chains.
-// Derive common traits for easy hashing/serialization and use in fuzzing pipelines.
+// Focus: enums, structs, and traits representing types, values, resource
+// locations, facts (preconditions), effects (postconditions), calls, and
+// chains. Derive common traits for easy hashing/serialization and use in
+// fuzzing pipelines.
+
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::BTreeMap;
 
 /// High-level type tags (mirrors Aptos' TypeTag but simplified)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -55,8 +57,9 @@ impl<'de> Deserialize<'de> for TypeTagLite {
     where
         D: Deserializer<'de>,
     {
-        use serde::de::{self, MapAccess, Visitor};
         use std::fmt;
+
+        use serde::de::{self, MapAccess, Visitor};
 
         struct TypeTagVisitor;
 
@@ -121,7 +124,8 @@ pub struct StructTag {
     pub ty_args: Vec<TypeTagLite>,
 }
 
-/// A variable id used inside MIR programs. Variables carry a type tag when known.
+/// A variable id used inside MIR programs. Variables carry a type tag when
+/// known.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Var {
     pub id: u32,
@@ -145,25 +149,18 @@ pub enum AddrExpr {
     Literal(String),
     /// An address coming from a Var (e.g., signer var)
     Var(Var),
-    /// Object address computed as object::create_object_address(owner, seed_expr)
-    ObjectAddr {
-        owner: Box<AddrExpr>,
-        seed: SeedExpr,
-    },
+    /// Object address computed as object::create_object_address(owner,
+    /// seed_expr)
+    ObjectAddr { owner: Box<AddrExpr>, seed: SeedExpr },
     /// Derived from a call result (call id + result var)
     FromCall { call_id: usize, result: Var },
-    /// Address read from a resource field at runtime (e.g., seller from Listing)
-    /// This allows fuzzer to track data dependencies across resources
-    FromField {
-        res: Box<ResLoc>,
-        field_path: String,
-    },
+    /// Address read from a resource field at runtime (e.g., seller from
+    /// Listing) This allows fuzzer to track data dependencies across
+    /// resources
+    FromField { res: Box<ResLoc>, field_path: String },
     /// Named object address computed deterministically from creator and seed
     /// e.g., object::create_named_object(creator, seed)
-    NamedObjectAddr {
-        creator: Box<AddrExpr>,
-        seed: SeedExpr,
-    },
+    NamedObjectAddr { creator: Box<AddrExpr>, seed: SeedExpr },
 }
 
 /// Seed expressions for object addresses (small domain expressions)
@@ -179,8 +176,9 @@ pub enum SeedExpr {
     Bytes(Vec<u8>),
     /// String converted to bytes seed
     Str(String),
-    /// Composite seed combining multiple components (e.g., issuer_addr || holder_addr)
-    /// Useful for paired object addresses like (issuer, holder) -> holding_address
+    /// Composite seed combining multiple components (e.g., issuer_addr ||
+    /// holder_addr) Useful for paired object addresses like (issuer,
+    /// holder) -> holding_address
     Composite(Vec<SeedExpr>),
     /// Seed from a function call result
     FromCall {
@@ -195,10 +193,7 @@ pub enum SeedExpr {
     /// BCS serialization of an expression
     BcsToBytes(Box<SeedExpr>),
     /// String formatting operation (e.g., format!("{}_{}", addr, counter))
-    Format {
-        template: String,
-        args: Vec<SeedExpr>,
-    },
+    Format { template: String, args: Vec<SeedExpr> },
     /// Address literal (for use in seed generation)
     Address(String),
 }
@@ -206,16 +201,18 @@ pub enum SeedExpr {
 /// Resource locator — identifies a resource type and the address where it lives
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResLoc {
-    pub struct_name: String,  // Reference to struct in struct_defs, e.g. "@TodoList"
+    pub struct_name: String, // Reference to struct in struct_defs, e.g. "@TodoList"
     pub addr: AddrExpr,
 }
 
-/// Facts: preconditions the fuzzer can reason about (Exists, NotExists, bounds, field equality...)
+/// Facts: preconditions the fuzzer can reason about (Exists, NotExists, bounds,
+/// field equality...)
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Fact {
     Exists(ResLoc),
     NotExists(ResLoc),
-    /// A weak fact: length at field_path is >= n. field_path is a simple dot-separated string.
+    /// A weak fact: length at field_path is >= n. field_path is a simple
+    /// dot-separated string.
     LengthAtLeast {
         res: ResLoc,
         field_path: String,
@@ -300,7 +297,8 @@ pub enum Effect {
     },
 }
 
-/// The kind of argument passed to a call. Can be a literal, a var reference, or a ResLoc.
+/// The kind of argument passed to a call. Can be a literal, a var reference, or
+/// a ResLoc.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Arg {
     Lit(Literal),
@@ -322,10 +320,12 @@ pub struct Call {
     /// Type args (concrete or TypeVar placeholders)
     pub ty_args: Vec<TypeTagLite>,
 
-    /// Arguments (in order). These are either Vars (which themselves may be bound to AddrExpr) or literals.
+    /// Arguments (in order). These are either Vars (which themselves may be
+    /// bound to AddrExpr) or literals.
     pub args: Vec<Arg>,
 
-    /// Resources listed in `acquires` in the function signature (struct name references)
+    /// Resources listed in `acquires` in the function signature (struct name
+    /// references)
     pub acquires: Vec<String>,
 
     /// Static + inferred requires
@@ -382,7 +382,8 @@ pub struct StructDef {
 }
 
 /// A Chain (program) — sequence of Calls with an optional final return var.
-/// Chains are the unit the fuzzer will mutate, insert provider calls into, and execute.
+/// Chains are the unit the fuzzer will mutate, insert provider calls into, and
+/// execute.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Chain {
     pub calls: Vec<Call>,
@@ -415,54 +416,56 @@ impl Chain {
     pub fn is_empty(&self) -> bool {
         self.calls.is_empty()
     }
-    
+
     pub fn sort_by_dependencies(&mut self) {
         use std::collections::{HashMap, HashSet};
-        
+
         let mut creates: HashMap<usize, HashSet<String>> = HashMap::new();
         let mut requires: HashMap<usize, HashSet<String>> = HashMap::new();
-        
+
         for (idx, call) in self.calls.iter().enumerate() {
             for effect in &call.effects {
                 if let Effect::Creates(res_loc) = effect {
                     creates.entry(idx).or_default().insert(res_loc.struct_name.clone());
                 }
             }
-            
+
             for fact in &call.requires {
                 if let Fact::Exists(res_loc) = fact {
                     requires.entry(idx).or_default().insert(res_loc.struct_name.clone());
                 }
             }
         }
-        
+
         let mut sorted_indices = Vec::new();
         let mut satisfied_structs: HashSet<String> = HashSet::new();
         let mut remaining: HashSet<usize> = (0..self.calls.len()).collect();
-        
+
         while !remaining.is_empty() {
             let mut made_progress = false;
-            
-            let candidates: Vec<usize> = remaining.iter()
+
+            let candidates: Vec<usize> = remaining
+                .iter()
                 .filter(|&&idx| {
-                    requires.get(&idx)
+                    requires
+                        .get(&idx)
                         .map(|reqs| reqs.iter().all(|s| satisfied_structs.contains(s)))
                         .unwrap_or(true)
                 })
                 .copied()
                 .collect();
-            
+
             for idx in candidates {
                 sorted_indices.push(idx);
                 remaining.remove(&idx);
-                
+
                 if let Some(created) = creates.get(&idx) {
                     satisfied_structs.extend(created.iter().cloned());
                 }
-                
+
                 made_progress = true;
             }
-            
+
             if !made_progress {
                 let mut rest: Vec<_> = remaining.iter().copied().collect();
                 rest.sort();
@@ -470,31 +473,35 @@ impl Chain {
                 break;
             }
         }
-        
+
         let mut new_calls = Vec::with_capacity(self.calls.len());
         for idx in sorted_indices {
             new_calls.push(self.calls[idx].clone());
         }
         self.calls = new_calls;
     }
-    
+
     pub fn calls_creating_struct(&self, struct_name: &str) -> Vec<usize> {
-        self.calls.iter().enumerate()
+        self.calls
+            .iter()
+            .enumerate()
             .filter(|(_, call)| {
-                call.effects.iter().any(|eff| {
-                    matches!(eff, Effect::Creates(res) if res.struct_name == struct_name)
-                })
+                call.effects
+                    .iter()
+                    .any(|eff| matches!(eff, Effect::Creates(res) if res.struct_name == struct_name))
             })
             .map(|(idx, _)| idx)
             .collect()
     }
-    
+
     pub fn calls_requiring_struct(&self, struct_name: &str) -> Vec<usize> {
-        self.calls.iter().enumerate()
+        self.calls
+            .iter()
+            .enumerate()
             .filter(|(_, call)| {
-                call.requires.iter().any(|fact| {
-                    matches!(fact, Fact::Exists(res) if res.struct_name == struct_name)
-                })
+                call.requires
+                    .iter()
+                    .any(|fact| matches!(fact, Fact::Exists(res) if res.struct_name == struct_name))
             })
             .map(|(idx, _)| idx)
             .collect()
@@ -503,10 +510,12 @@ impl Chain {
 
 // --------------------------- Traits & Helpers -------------------------------
 
-/// A trait to unify address expressions with concrete addresses or other expressions.
-/// Implementations can do simple structural unification or heuristic binding.
+/// A trait to unify address expressions with concrete addresses or other
+/// expressions. Implementations can do simple structural unification or
+/// heuristic binding.
 pub trait UnifyAddr {
-    /// Try to unify `self` with `other` and return a (possibly partial) substitution
+    /// Try to unify `self` with `other` and return a (possibly partial)
+    /// substitution
     fn unify(&self, other: &AddrExpr) -> Option<BTreeMap<String, AddrExpr>>;
 }
 
@@ -568,16 +577,7 @@ impl UnifyAddr for AddrExpr {
             }
 
             // ObjectAddr <> ObjectAddr: unify owner and seed
-            (
-                AddrExpr::ObjectAddr {
-                    owner: o1,
-                    seed: s1,
-                },
-                AddrExpr::ObjectAddr {
-                    owner: o2,
-                    seed: s2,
-                },
-            ) => {
+            (AddrExpr::ObjectAddr { owner: o1, seed: s1 }, AddrExpr::ObjectAddr { owner: o2, seed: s2 }) => {
                 if let Some(m1) = o1.unify(o2) {
                     // merge maps
                     for (k, v) in m1.into_iter() {
@@ -622,7 +622,8 @@ impl UnifyAddr for AddrExpr {
     }
 }
 
-// Utilities to convert a SeedExpr into a trivial AddrExpr when recording seed bindings
+// Utilities to convert a SeedExpr into a trivial AddrExpr when recording seed
+// bindings
 impl AddrExpr {
     fn from_seed(s: SeedExpr) -> AddrExpr {
         match s {
@@ -649,57 +650,27 @@ impl std::fmt::Display for Fact {
             Fact::LengthAtLeast { res, field_path, n } => {
                 write!(f, "Len({}.{}) >= {}", res.struct_name, field_path, n)
             }
-            Fact::FieldEq {
-                res,
-                field_path,
-                value,
-            } => write!(
-                f,
-                "FieldEq({}.{} == {:?})",
-                res.struct_name, field_path, value
-            ),
+            Fact::FieldEq { res, field_path, value } => {
+                write!(f, "FieldEq({}.{} == {:?})", res.struct_name, field_path, value)
+            }
             Fact::FieldExists { res, field_path } => {
                 write!(f, "FieldExists({}.{})", res.struct_name, field_path)
             }
             Fact::FieldNotExists { res, field_path } => {
                 write!(f, "FieldNotExists({}.{})", res.struct_name, field_path)
             }
-            Fact::VectorContains {
-                res,
-                field_path,
-                value,
-            } => write!(
-                f,
-                "VectorContains({}.{}, {:?})",
-                res.struct_name, field_path, value
-            ),
-            Fact::VectorNotContains {
-                res,
-                field_path,
-                value,
-            } => write!(
-                f,
-                "VectorNotContains({}.{}, {:?})",
-                res.struct_name, field_path, value
-            ),
-            Fact::FieldGte {
-                res,
-                field_path,
-                value,
-            } => write!(
-                f,
-                "FieldGte({}.{} >= {})",
-                res.struct_name, field_path, value
-            ),
-            Fact::FieldGt {
-                res,
-                field_path,
-                value,
-            } => write!(
-                f,
-                "FieldGt({}.{} > {})",
-                res.struct_name, field_path, value
-            ),
+            Fact::VectorContains { res, field_path, value } => {
+                write!(f, "VectorContains({}.{}, {:?})", res.struct_name, field_path, value)
+            }
+            Fact::VectorNotContains { res, field_path, value } => {
+                write!(f, "VectorNotContains({}.{}, {:?})", res.struct_name, field_path, value)
+            }
+            Fact::FieldGte { res, field_path, value } => {
+                write!(f, "FieldGte({}.{} >= {})", res.struct_name, field_path, value)
+            }
+            Fact::FieldGt { res, field_path, value } => {
+                write!(f, "FieldGt({}.{} > {})", res.struct_name, field_path, value)
+            }
             Fact::And(a, b) => write!(f, "({} AND {})", a, b),
             Fact::Or(a, b) => write!(f, "({} OR {})", a, b),
         }
@@ -716,78 +687,76 @@ pub fn resloc_simple(struct_name: &str, addr: AddrExpr) -> ResLoc {
     }
 }
 
-// -------------------- Chain to Aptos Transaction Conversion --------------------
+// -------------------- Chain to Aptos Transaction Conversion
+// --------------------
 
+use aptos_dynamic_transaction_composer::CallArgument;
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::ModuleId;
 use aptos_vm::aptos_vm::FUZZER_SENDER;
 use bcs;
 
-use crate::input::FuncCall;
+use crate::input::Call as FuzzCall;
 
 impl Chain {
-    /// Convert Chain calls to FuncCall inputs
-    pub fn to_func_calls(&self) -> Result<Vec<FuncCall>, String> {
-        let mut func_calls = Vec::new();
-        
+    /// Convert Chain calls to fuzzer Call inputs
+    pub fn to_calls(&self) -> Result<Vec<FuzzCall>, String> {
+        let mut out = Vec::new();
         for call in &self.calls {
-            let func_call = call_to_func_call(call)?;
-            func_calls.push(func_call);
+            let c = call_to_fuzz_call(call)?;
+            out.push(c);
         }
-        
-        Ok(func_calls)
+        Ok(out)
     }
 }
 
-fn call_to_func_call(call: &Call) -> Result<FuncCall, String> {
+fn call_to_fuzz_call(call: &Call) -> Result<FuzzCall, String> {
     // Parse module address
-    let addr_bytes = hex::decode(&call.module_addr)
-        .map_err(|e| format!("Invalid module address: {}", e))?;
+    let addr_bytes = hex::decode(&call.module_addr).map_err(|e| format!("Invalid module address: {}", e))?;
     if addr_bytes.len() != 32 {
         return Err(format!("Module address must be 32 bytes, got {}", addr_bytes.len()));
     }
     let mut addr_array = [0u8; 32];
     addr_array.copy_from_slice(&addr_bytes);
     let module_addr = AccountAddress::new(addr_array);
-    
+
     // Parse module and function names
-    let module_name = Identifier::new(call.module.as_str())
-        .map_err(|e| format!("Invalid module name: {}", e))?;
-    let function_name = Identifier::new(call.function.as_str())
-        .map_err(|e| format!("Invalid function name: {}", e))?;
-    
+    let module_name = Identifier::new(call.module.as_str()).map_err(|e| format!("Invalid module name: {}", e))?;
+    let function_name = Identifier::new(call.function.as_str()).map_err(|e| format!("Invalid function name: {}", e))?;
+
     let module_id = ModuleId::new(module_addr, module_name);
-    
+
     let ty_args = vec![];
-    
-    // Convert args to BCS-encoded values (skip Signer type as it's provided by sender)
-    let mut bcs_args = Vec::new();
+
+    // Convert args to CallArgument (Signer/Raw only for now)
+    let mut args: Vec<CallArgument> = Vec::new();
     for arg in &call.args {
         match arg {
             Arg::Var(var) => {
                 if let Some(ref ty) = var.ty {
-                    // Skip Signer type - it's automatically provided by the transaction sender
                     if matches!(ty, TypeTagLite::Signer) {
-                        continue;
+                        // Use signer index 0 by default
+                        args.push(CallArgument::Signer(0));
+                    } else {
+                        let bytes = generate_value_for_type(ty)?;
+                        args.push(CallArgument::Raw(bytes));
                     }
-                    let bytes = generate_value_for_type(ty)?;
-                    bcs_args.push(bytes);
                 } else {
                     return Err(format!("Var {} has no type information", var.id));
                 }
             }
             Arg::Lit(lit) => {
                 let bytes = literal_to_bcs(lit)?;
-                bcs_args.push(bytes);
+                args.push(CallArgument::Raw(bytes));
             }
             Arg::Res(_res) => {
                 return Err("Resource arguments not yet supported".to_string());
             }
         }
     }
-    
-    Ok(FuncCall::new(module_id, function_name, ty_args, bcs_args))
+
+    Ok(FuzzCall::new(module_id, function_name, ty_args, args))
 }
 
 fn generate_value_for_type(ty: &TypeTagLite) -> Result<Vec<u8>, String> {
@@ -811,8 +780,7 @@ fn literal_to_bcs(lit: &Literal) -> Result<Vec<u8>, String> {
         Literal::Bool(b) => bcs::to_bytes(b).map_err(|e| e.to_string()),
         Literal::U64(n) => bcs::to_bytes(n).map_err(|e| e.to_string()),
         Literal::Address(s) => {
-            let addr_bytes = hex::decode(s)
-                .map_err(|e| format!("Invalid address: {}", e))?;
+            let addr_bytes = hex::decode(s).map_err(|e| format!("Invalid address: {}", e))?;
             if addr_bytes.len() != 32 {
                 return Err(format!("Address must be 32 bytes"));
             }

--- a/crates/aptos-fuzzer/src/mir.rs
+++ b/crates/aptos-fuzzer/src/mir.rs
@@ -415,6 +415,90 @@ impl Chain {
     pub fn is_empty(&self) -> bool {
         self.calls.is_empty()
     }
+    
+    pub fn sort_by_dependencies(&mut self) {
+        use std::collections::{HashMap, HashSet};
+        
+        let mut creates: HashMap<usize, HashSet<String>> = HashMap::new();
+        let mut requires: HashMap<usize, HashSet<String>> = HashMap::new();
+        
+        for (idx, call) in self.calls.iter().enumerate() {
+            for effect in &call.effects {
+                if let Effect::Creates(res_loc) = effect {
+                    creates.entry(idx).or_default().insert(res_loc.struct_name.clone());
+                }
+            }
+            
+            for fact in &call.requires {
+                if let Fact::Exists(res_loc) = fact {
+                    requires.entry(idx).or_default().insert(res_loc.struct_name.clone());
+                }
+            }
+        }
+        
+        let mut sorted_indices = Vec::new();
+        let mut satisfied_structs: HashSet<String> = HashSet::new();
+        let mut remaining: HashSet<usize> = (0..self.calls.len()).collect();
+        
+        while !remaining.is_empty() {
+            let mut made_progress = false;
+            
+            let candidates: Vec<usize> = remaining.iter()
+                .filter(|&&idx| {
+                    requires.get(&idx)
+                        .map(|reqs| reqs.iter().all(|s| satisfied_structs.contains(s)))
+                        .unwrap_or(true)
+                })
+                .copied()
+                .collect();
+            
+            for idx in candidates {
+                sorted_indices.push(idx);
+                remaining.remove(&idx);
+                
+                if let Some(created) = creates.get(&idx) {
+                    satisfied_structs.extend(created.iter().cloned());
+                }
+                
+                made_progress = true;
+            }
+            
+            if !made_progress {
+                let mut rest: Vec<_> = remaining.iter().copied().collect();
+                rest.sort();
+                sorted_indices.extend(rest);
+                break;
+            }
+        }
+        
+        let mut new_calls = Vec::with_capacity(self.calls.len());
+        for idx in sorted_indices {
+            new_calls.push(self.calls[idx].clone());
+        }
+        self.calls = new_calls;
+    }
+    
+    pub fn calls_creating_struct(&self, struct_name: &str) -> Vec<usize> {
+        self.calls.iter().enumerate()
+            .filter(|(_, call)| {
+                call.effects.iter().any(|eff| {
+                    matches!(eff, Effect::Creates(res) if res.struct_name == struct_name)
+                })
+            })
+            .map(|(idx, _)| idx)
+            .collect()
+    }
+    
+    pub fn calls_requiring_struct(&self, struct_name: &str) -> Vec<usize> {
+        self.calls.iter().enumerate()
+            .filter(|(_, call)| {
+                call.requires.iter().any(|fact| {
+                    matches!(fact, Fact::Exists(res) if res.struct_name == struct_name)
+                })
+            })
+            .map(|(idx, _)| idx)
+            .collect()
+    }
 }
 
 // --------------------------- Traits & Helpers -------------------------------
@@ -637,25 +721,25 @@ pub fn resloc_simple(struct_name: &str, addr: AddrExpr) -> ResLoc {
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::ModuleId;
-use aptos_types::transaction::{EntryFunction, TransactionPayload};
+use aptos_types::transaction::EntryFunction;
 use aptos_vm::aptos_vm::FUZZER_SENDER;
 use bcs;
 
 impl Chain {
-    /// Convert Chain calls to TransactionPayloads
-    pub fn to_transaction_payload(&self) -> Result<Vec<TransactionPayload>, String> {
-        let mut payloads = Vec::new();
+    /// Convert Chain calls to Input calls
+    pub fn to_entry_functions(&self) -> Result<Vec<EntryFunction>, String> {
+        let mut functions = Vec::new();
         
         for call in &self.calls {
-            let payload = call_to_payload(call)?;
-            payloads.push(payload);
+            let entry_fn = call_to_entry_function(call)?;
+            functions.push(entry_fn);
         }
         
-        Ok(payloads)
+        Ok(functions)
     }
 }
 
-fn call_to_payload(call: &Call) -> Result<TransactionPayload, String> {
+fn call_to_entry_function(call: &Call) -> Result<EntryFunction, String> {
     // Parse module address
     let addr_bytes = hex::decode(&call.module_addr)
         .map_err(|e| format!("Invalid module address: {}", e))?;
@@ -703,7 +787,7 @@ fn call_to_payload(call: &Call) -> Result<TransactionPayload, String> {
     }
     
     let entry_fn = EntryFunction::new(module_id, function_name, ty_args, bcs_args);
-    Ok(TransactionPayload::EntryFunction(entry_fn))
+    Ok(entry_fn)
 }
 
 fn generate_value_for_type(ty: &TypeTagLite) -> Result<Vec<u8>, String> {

--- a/crates/aptos-fuzzer/src/mir.rs
+++ b/crates/aptos-fuzzer/src/mir.rs
@@ -1,0 +1,743 @@
+// Suggested MIR Rust definitions for crates/aptos-fuzzer/src/mir/ir.rs
+// Designed to be a compact, expressive IR for Move interactions (MIR)
+// Focus: enums, structs, and traits representing types, values, resource locations,
+// facts (preconditions), effects (postconditions), calls, and chains.
+// Derive common traits for easy hashing/serialization and use in fuzzing pipelines.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+
+/// High-level type tags (mirrors Aptos' TypeTag but simplified)
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TypeTagLite {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Signer,
+    Vector(Box<TypeTagLite>),
+    Struct(StructTag),
+    TypeVar(u32), // a type parameter placeholder
+}
+
+impl Serialize for TypeTagLite {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            TypeTagLite::Bool => serializer.serialize_str("Bool"),
+            TypeTagLite::U8 => serializer.serialize_str("U8"),
+            TypeTagLite::U64 => serializer.serialize_str("U64"),
+            TypeTagLite::U128 => serializer.serialize_str("U128"),
+            TypeTagLite::Address => serializer.serialize_str("Address"),
+            TypeTagLite::Signer => serializer.serialize_str("Signer"),
+            TypeTagLite::Vector(inner) => {
+                use serde::ser::SerializeStruct;
+                let mut s = serializer.serialize_struct("Vector", 1)?;
+                s.serialize_field("Vector", inner.as_ref())?;
+                s.end()
+            }
+            TypeTagLite::Struct(s) => s.serialize(serializer),
+            TypeTagLite::TypeVar(v) => {
+                use serde::ser::SerializeStruct;
+                let mut st = serializer.serialize_struct("TypeVar", 1)?;
+                st.serialize_field("TypeVar", v)?;
+                st.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeTagLite {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, MapAccess, Visitor};
+        use std::fmt;
+
+        struct TypeTagVisitor;
+
+        impl<'de> Visitor<'de> for TypeTagVisitor {
+            type Value = TypeTagLite;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a TypeTagLite string or struct")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<TypeTagLite, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "Bool" => Ok(TypeTagLite::Bool),
+                    "U8" => Ok(TypeTagLite::U8),
+                    "U64" => Ok(TypeTagLite::U64),
+                    "U128" => Ok(TypeTagLite::U128),
+                    "Address" => Ok(TypeTagLite::Address),
+                    "Signer" => Ok(TypeTagLite::Signer),
+                    _ => Err(E::custom(format!("Unknown type: {}", value))),
+                }
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<TypeTagLite, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                if let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "Vector" => {
+                            let inner: TypeTagLite = map.next_value()?;
+                            Ok(TypeTagLite::Vector(Box::new(inner)))
+                        }
+                        "Struct" => {
+                            let s: StructTag = map.next_value()?;
+                            Ok(TypeTagLite::Struct(s))
+                        }
+                        "TypeVar" => {
+                            let v: u32 = map.next_value()?;
+                            Ok(TypeTagLite::TypeVar(v))
+                        }
+                        _ => Err(de::Error::unknown_field(&key, &["Vector", "Struct", "TypeVar"])),
+                    }
+                } else {
+                    Err(de::Error::custom("expected a type tag"))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(TypeTagVisitor)
+    }
+}
+
+/// A struct tag: (address, module, name, optional type args)
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct StructTag {
+    pub address: String, // use string for textual module address (e.g., 0x1)
+    pub module: String,
+    pub name: String,
+    pub ty_args: Vec<TypeTagLite>,
+}
+
+/// A variable id used inside MIR programs. Variables carry a type tag when known.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Var {
+    pub id: u32,
+    pub ty: Option<TypeTagLite>,
+}
+
+impl Var {
+    pub fn new(id: u32) -> Self {
+        Self { id, ty: None }
+    }
+    pub fn with_ty(id: u32, ty: TypeTagLite) -> Self {
+        Self { id, ty: Some(ty) }
+    }
+}
+
+/// Address expressions — how an address is computed or referenced. This is
+/// intentionally lightweight but expressive enough for object addresses.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AddrExpr {
+    /// A concrete literal address, e.g. 0x1
+    Literal(String),
+    /// An address coming from a Var (e.g., signer var)
+    Var(Var),
+    /// Object address computed as object::create_object_address(owner, seed_expr)
+    ObjectAddr {
+        owner: Box<AddrExpr>,
+        seed: SeedExpr,
+    },
+    /// Derived from a call result (call id + result var)
+    FromCall { call_id: usize, result: Var },
+    /// Address read from a resource field at runtime (e.g., seller from Listing)
+    /// This allows fuzzer to track data dependencies across resources
+    FromField {
+        res: Box<ResLoc>,
+        field_path: String,
+    },
+    /// Named object address computed deterministically from creator and seed
+    /// e.g., object::create_named_object(creator, seed)
+    NamedObjectAddr {
+        creator: Box<AddrExpr>,
+        seed: SeedExpr,
+    },
+}
+
+/// Seed expressions for object addresses (small domain expressions)
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SeedExpr {
+    /// A small integer literal
+    Lit(u64),
+    /// A small variable (often a u64 local)
+    Var(Var),
+    /// A named counter (e.g., user_todo_counter)
+    Counter(String),
+    /// Bytes literal seed
+    Bytes(Vec<u8>),
+    /// String converted to bytes seed
+    Str(String),
+    /// Composite seed combining multiple components (e.g., issuer_addr || holder_addr)
+    /// Useful for paired object addresses like (issuer, holder) -> holding_address
+    Composite(Vec<SeedExpr>),
+    /// Seed from a function call result
+    FromCall {
+        module: String,
+        function: String,
+        args: Vec<SeedExpr>,
+        /// Optional expansion of the function's internal implementation
+        /// e.g., for construct_todo_list_object_seed, this would contain the
+        /// BcsToBytes(Format { ... }) expression
+        expansion: Option<Box<SeedExpr>>,
+    },
+    /// BCS serialization of an expression
+    BcsToBytes(Box<SeedExpr>),
+    /// String formatting operation (e.g., format!("{}_{}", addr, counter))
+    Format {
+        template: String,
+        args: Vec<SeedExpr>,
+    },
+    /// Address literal (for use in seed generation)
+    Address(String),
+}
+
+/// Resource locator — identifies a resource type and the address where it lives
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResLoc {
+    pub struct_name: String,  // Reference to struct in struct_defs, e.g. "@TodoList"
+    pub addr: AddrExpr,
+}
+
+/// Facts: preconditions the fuzzer can reason about (Exists, NotExists, bounds, field equality...)
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Fact {
+    Exists(ResLoc),
+    NotExists(ResLoc),
+    /// A weak fact: length at field_path is >= n. field_path is a simple dot-separated string.
+    LengthAtLeast {
+        res: ResLoc,
+        field_path: String,
+        n: usize,
+    },
+    /// Field equals a literal value
+    FieldEq {
+        res: ResLoc,
+        field_path: String,
+        value: Literal,
+    },
+    /// Field exists (for optional fields)
+    FieldExists {
+        res: ResLoc,
+        field_path: String,
+    },
+    /// Field does not exist (for optional fields)
+    FieldNotExists {
+        res: ResLoc,
+        field_path: String,
+    },
+    /// Vector/SmartVector contains an address value
+    VectorContains {
+        res: ResLoc,
+        field_path: String,
+        value: AddrExpr,
+    },
+    /// Vector/SmartVector does not contain an address value
+    VectorNotContains {
+        res: ResLoc,
+        field_path: String,
+        value: AddrExpr,
+    },
+    /// Numeric field comparison: field >= value
+    FieldGte {
+        res: ResLoc,
+        field_path: String,
+        value: u64,
+    },
+    /// Numeric field comparison: field > value
+    FieldGt {
+        res: ResLoc,
+        field_path: String,
+        value: u64,
+    },
+    /// Boolean AND of two facts (for complex conditions)
+    And(Box<Fact>, Box<Fact>),
+    /// Boolean OR of two facts (for alternative conditions)
+    Or(Box<Fact>, Box<Fact>),
+}
+
+/// Simple literal values that can appear in args or facts
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Literal {
+    Bool(bool),
+    U64(u64),
+    Address(String),
+    Bytes(Vec<u8>),
+    Str(String),
+}
+
+/// Effects — best-effort predictions of what a call produces
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Effect {
+    Creates(ResLoc),
+    Deletes(ResLoc),
+    Writes(ResLoc),
+    EmitsEvent {
+        tag: String,
+        fields: Vec<Literal>,
+    },
+    /// e.g., mints coin amounts, or transfers
+    Mints {
+        coin_ty: TypeTagLite,
+        amount: u128,
+        to: AddrExpr,
+    },
+    /// returns a new object address (for convenience)
+    NewObjectAddr {
+        result: Var,
+        addr: AddrExpr,
+    },
+}
+
+/// The kind of argument passed to a call. Can be a literal, a var reference, or a ResLoc.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Arg {
+    Lit(Literal),
+    Var(Var),
+    /// a reference to a resource location (resolved to an address expression)
+    Res(ResLoc),
+}
+
+/// A MIR Call — describing a Move entry function or script call
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Call {
+    /// Unique id within a Chain (helps attribute coverage)
+    pub id: usize,
+    /// canonical module address (string) and module name
+    pub module_addr: String,
+    pub module: String,
+    pub function: String,
+
+    /// Type args (concrete or TypeVar placeholders)
+    pub ty_args: Vec<TypeTagLite>,
+
+    /// Arguments (in order). These are either Vars (which themselves may be bound to AddrExpr) or literals.
+    pub args: Vec<Arg>,
+
+    /// Resources listed in `acquires` in the function signature (struct name references)
+    pub acquires: Vec<String>,
+
+    /// Static + inferred requires
+    pub requires: Vec<Fact>,
+
+    /// Predicted effects for provider search and chaining
+    pub effects: Vec<Effect>,
+
+    /// Return type of the function (if any)
+    pub ret: Option<TypeTagLite>,
+}
+
+impl Call {
+    pub fn new(
+        id: usize,
+        module_addr: impl Into<String>,
+        module: impl Into<String>,
+        function: impl Into<String>,
+    ) -> Self {
+        Self {
+            id,
+            module_addr: module_addr.into(),
+            module: module.into(),
+            function: function.into(),
+            ty_args: vec![],
+            args: vec![],
+            acquires: vec![],
+            requires: vec![],
+            effects: vec![],
+            ret: None,
+        }
+    }
+
+    pub fn description(&self) -> String {
+        format!(
+            "{}::{}::{}(ty_args={:?}, args={:?})",
+            self.module_addr, self.module, self.function, self.ty_args, self.args
+        )
+    }
+}
+
+/// Field definition for a struct
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FieldDef {
+    pub name: String,
+    pub ty: TypeTagLite,
+}
+
+/// Complete struct definition including fields
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StructDef {
+    pub tag: StructTag,
+    pub fields: Vec<FieldDef>,
+}
+
+/// A Chain (program) — sequence of Calls with an optional final return var.
+/// Chains are the unit the fuzzer will mutate, insert provider calls into, and execute.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Chain {
+    pub calls: Vec<Call>,
+    /// Map of struct name to struct definition (including nested structs)
+    pub struct_defs: BTreeMap<String, StructDef>,
+    /// a small, optional metadata bag to store learned state snapshots etc.
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl Default for Chain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Chain {
+    pub fn new() -> Self {
+        Self {
+            calls: vec![],
+            struct_defs: BTreeMap::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+    pub fn push(&mut self, c: Call) {
+        self.calls.push(c);
+    }
+    pub fn len(&self) -> usize {
+        self.calls.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.calls.is_empty()
+    }
+}
+
+// --------------------------- Traits & Helpers -------------------------------
+
+/// A trait to unify address expressions with concrete addresses or other expressions.
+/// Implementations can do simple structural unification or heuristic binding.
+pub trait UnifyAddr {
+    /// Try to unify `self` with `other` and return a (possibly partial) substitution
+    fn unify(&self, other: &AddrExpr) -> Option<BTreeMap<String, AddrExpr>>;
+}
+
+impl UnifyAddr for AddrExpr {
+    fn unify(&self, other: &AddrExpr) -> Option<BTreeMap<String, AddrExpr>> {
+        // Substitution map: keys are identifiers like "v{id}" for Var bindings
+        // and "seed:{name}" for named seed bindings. Values are AddrExprs.
+        type Subst = BTreeMap<String, AddrExpr>;
+        fn unify_seed(s1: &SeedExpr, s2: &SeedExpr, subst: &mut Subst) -> bool {
+            match (s1, s2) {
+                (SeedExpr::Lit(a), SeedExpr::Lit(b)) => a == b,
+                (SeedExpr::Var(v), other) => {
+                    let k = format!("v{}", v.id);
+                    subst.insert(k, AddrExpr::from_seed(other.clone()));
+                    true
+                }
+                (SeedExpr::Counter(n), SeedExpr::Counter(m)) => n == m,
+                (SeedExpr::Lit(_a), SeedExpr::Var(v)) => {
+                    let k = format!("v{}", v.id);
+                    subst.insert(k, AddrExpr::from_seed(s1.clone()));
+                    true
+                }
+                // conservative fallback: don't unify different kinds
+                _ => false,
+            }
+        }
+
+        let mut map: Subst = BTreeMap::new();
+        // Helper to bind a var key -> addrexpr, but keep existing binding consistent
+        let bind = |k: String, v: AddrExpr, map: &mut Subst| -> bool {
+            if let Some(existing) = map.get(&k) {
+                existing == &v
+            } else {
+                map.insert(k, v);
+                true
+            }
+        };
+
+        match (self, other) {
+            // identical literals
+            (AddrExpr::Literal(a), AddrExpr::Literal(b)) if a == b => Some(map),
+
+            // a Var can unify with anything: record substitution v{id} -> other
+            (AddrExpr::Var(v), other) => {
+                let k = format!("v{}", v.id);
+                if bind(k, other.clone(), &mut map) {
+                    Some(map)
+                } else {
+                    None
+                }
+            }
+            (other, AddrExpr::Var(v)) => {
+                let k = format!("v{}", v.id);
+                if bind(k, other.clone(), &mut map) {
+                    Some(map)
+                } else {
+                    None
+                }
+            }
+
+            // ObjectAddr <> ObjectAddr: unify owner and seed
+            (
+                AddrExpr::ObjectAddr {
+                    owner: o1,
+                    seed: s1,
+                },
+                AddrExpr::ObjectAddr {
+                    owner: o2,
+                    seed: s2,
+                },
+            ) => {
+                if let Some(m1) = o1.unify(o2) {
+                    // merge maps
+                    for (k, v) in m1.into_iter() {
+                        map.insert(k, v);
+                    }
+                    // unify seeds (allow binding seed vars)
+                    if unify_seed(s1, s2, &mut map) {
+                        Some(map)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+
+            // FromCall reverse binding:
+            // If one side is FromCall{call_id, result} and the other is a concrete AddrExpr,
+            // bind a special key `call:{call_id}:r{varid}` -> addrexpr so callers can substitute
+            (AddrExpr::FromCall { call_id, result }, other) => {
+                let k = format!("call:{}:r{}", call_id, result.id);
+                if bind(k, other.clone(), &mut map) {
+                    Some(map)
+                } else {
+                    None
+                }
+            }
+            (other, AddrExpr::FromCall { call_id, result }) => {
+                let k = format!("call:{}:r{}", call_id, result.id);
+                if bind(k, other.clone(), &mut map) {
+                    Some(map)
+                } else {
+                    None
+                }
+            }
+
+            // Fallback: try structural equality for simple cases
+            (a, b) if a == b => Some(map),
+
+            _ => None,
+        }
+    }
+}
+
+// Utilities to convert a SeedExpr into a trivial AddrExpr when recording seed bindings
+impl AddrExpr {
+    fn from_seed(s: SeedExpr) -> AddrExpr {
+        match s {
+            SeedExpr::Lit(n) => AddrExpr::Literal(format!("seed:{}", n)),
+            SeedExpr::Var(v) => AddrExpr::Var(v),
+            SeedExpr::Counter(name) => AddrExpr::Literal(format!("counter:{}", name)),
+            SeedExpr::Bytes(b) => AddrExpr::Literal(format!("bytes:{}", hex::encode(b))),
+            SeedExpr::Str(s) => AddrExpr::Literal(format!("str:{}", s)),
+            SeedExpr::Composite(_) => AddrExpr::Literal("composite_seed".to_string()),
+            SeedExpr::FromCall { .. } => AddrExpr::Literal("from_call_seed".to_string()),
+            SeedExpr::BcsToBytes(_) => AddrExpr::Literal("bcs_seed".to_string()),
+            SeedExpr::Format { .. } => AddrExpr::Literal("format_seed".to_string()),
+            SeedExpr::Address(a) => AddrExpr::Literal(a),
+        }
+    }
+}
+
+/// Helpers to pretty-print Facts/Effects for logging during fuzzing
+impl std::fmt::Display for Fact {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Fact::Exists(r) => write!(f, "Exists({} @ {:?})", r.struct_name, r.addr),
+            Fact::NotExists(r) => write!(f, "NotExists({} @ {:?})", r.struct_name, r.addr),
+            Fact::LengthAtLeast { res, field_path, n } => {
+                write!(f, "Len({}.{}) >= {}", res.struct_name, field_path, n)
+            }
+            Fact::FieldEq {
+                res,
+                field_path,
+                value,
+            } => write!(
+                f,
+                "FieldEq({}.{} == {:?})",
+                res.struct_name, field_path, value
+            ),
+            Fact::FieldExists { res, field_path } => {
+                write!(f, "FieldExists({}.{})", res.struct_name, field_path)
+            }
+            Fact::FieldNotExists { res, field_path } => {
+                write!(f, "FieldNotExists({}.{})", res.struct_name, field_path)
+            }
+            Fact::VectorContains {
+                res,
+                field_path,
+                value,
+            } => write!(
+                f,
+                "VectorContains({}.{}, {:?})",
+                res.struct_name, field_path, value
+            ),
+            Fact::VectorNotContains {
+                res,
+                field_path,
+                value,
+            } => write!(
+                f,
+                "VectorNotContains({}.{}, {:?})",
+                res.struct_name, field_path, value
+            ),
+            Fact::FieldGte {
+                res,
+                field_path,
+                value,
+            } => write!(
+                f,
+                "FieldGte({}.{} >= {})",
+                res.struct_name, field_path, value
+            ),
+            Fact::FieldGt {
+                res,
+                field_path,
+                value,
+            } => write!(
+                f,
+                "FieldGt({}.{} > {})",
+                res.struct_name, field_path, value
+            ),
+            Fact::And(a, b) => write!(f, "({} AND {})", a, b),
+            Fact::Or(a, b) => write!(f, "({} OR {})", a, b),
+        }
+    }
+}
+
+// --------------------------- Example utility constructors ------------------
+
+/// Shorthand to build a ResLoc for tests / generator code
+pub fn resloc_simple(struct_name: &str, addr: AddrExpr) -> ResLoc {
+    ResLoc {
+        struct_name: format!("@{}", struct_name),
+        addr,
+    }
+}
+
+// -------------------- Chain to Aptos Transaction Conversion --------------------
+
+use aptos_move_core_types::account_address::AccountAddress;
+use aptos_move_core_types::identifier::Identifier;
+use aptos_move_core_types::language_storage::ModuleId;
+use aptos_types::transaction::{EntryFunction, TransactionPayload};
+use aptos_vm::aptos_vm::FUZZER_SENDER;
+use bcs;
+
+impl Chain {
+    /// Convert Chain calls to TransactionPayloads
+    pub fn to_transaction_payload(&self) -> Result<Vec<TransactionPayload>, String> {
+        let mut payloads = Vec::new();
+        
+        for call in &self.calls {
+            let payload = call_to_payload(call)?;
+            payloads.push(payload);
+        }
+        
+        Ok(payloads)
+    }
+}
+
+fn call_to_payload(call: &Call) -> Result<TransactionPayload, String> {
+    // Parse module address
+    let addr_bytes = hex::decode(&call.module_addr)
+        .map_err(|e| format!("Invalid module address: {}", e))?;
+    if addr_bytes.len() != 32 {
+        return Err(format!("Module address must be 32 bytes, got {}", addr_bytes.len()));
+    }
+    let mut addr_array = [0u8; 32];
+    addr_array.copy_from_slice(&addr_bytes);
+    let module_addr = AccountAddress::new(addr_array);
+    
+    // Parse module and function names
+    let module_name = Identifier::new(call.module.as_str())
+        .map_err(|e| format!("Invalid module name: {}", e))?;
+    let function_name = Identifier::new(call.function.as_str())
+        .map_err(|e| format!("Invalid function name: {}", e))?;
+    
+    let module_id = ModuleId::new(module_addr, module_name);
+    
+    let ty_args = vec![];
+    
+    // Convert args to BCS-encoded values (skip Signer type as it's provided by sender)
+    let mut bcs_args = Vec::new();
+    for arg in &call.args {
+        match arg {
+            Arg::Var(var) => {
+                if let Some(ref ty) = var.ty {
+                    // Skip Signer type - it's automatically provided by the transaction sender
+                    if matches!(ty, TypeTagLite::Signer) {
+                        continue;
+                    }
+                    let bytes = generate_value_for_type(ty)?;
+                    bcs_args.push(bytes);
+                } else {
+                    return Err(format!("Var {} has no type information", var.id));
+                }
+            }
+            Arg::Lit(lit) => {
+                let bytes = literal_to_bcs(lit)?;
+                bcs_args.push(bytes);
+            }
+            Arg::Res(_res) => {
+                return Err("Resource arguments not yet supported".to_string());
+            }
+        }
+    }
+    
+    let entry_fn = EntryFunction::new(module_id, function_name, ty_args, bcs_args);
+    Ok(TransactionPayload::EntryFunction(entry_fn))
+}
+
+fn generate_value_for_type(ty: &TypeTagLite) -> Result<Vec<u8>, String> {
+    match ty {
+        TypeTagLite::Bool => bcs::to_bytes(&false).map_err(|e| e.to_string()),
+        TypeTagLite::U8 => bcs::to_bytes(&0u8).map_err(|e| e.to_string()),
+        TypeTagLite::U64 => bcs::to_bytes(&0u64).map_err(|e| e.to_string()),
+        TypeTagLite::U128 => bcs::to_bytes(&0u128).map_err(|e| e.to_string()),
+        TypeTagLite::Address => bcs::to_bytes(&FUZZER_SENDER).map_err(|e| e.to_string()),
+        TypeTagLite::Signer => bcs::to_bytes(&FUZZER_SENDER).map_err(|e| e.to_string()),
+        TypeTagLite::Vector(_inner) => {
+            let empty: Vec<u8> = vec![];
+            bcs::to_bytes(&empty).map_err(|e| e.to_string())
+        }
+        _ => Err(format!("Unsupported type for value generation: {:?}", ty)),
+    }
+}
+
+fn literal_to_bcs(lit: &Literal) -> Result<Vec<u8>, String> {
+    match lit {
+        Literal::Bool(b) => bcs::to_bytes(b).map_err(|e| e.to_string()),
+        Literal::U64(n) => bcs::to_bytes(n).map_err(|e| e.to_string()),
+        Literal::Address(s) => {
+            let addr_bytes = hex::decode(s)
+                .map_err(|e| format!("Invalid address: {}", e))?;
+            if addr_bytes.len() != 32 {
+                return Err(format!("Address must be 32 bytes"));
+            }
+            let mut addr_array = [0u8; 32];
+            addr_array.copy_from_slice(&addr_bytes);
+            let addr = AccountAddress::new(addr_array);
+            bcs::to_bytes(&addr).map_err(|e| e.to_string())
+        }
+        Literal::Bytes(b) => bcs::to_bytes(b).map_err(|e| e.to_string()),
+        Literal::Str(s) => bcs::to_bytes(s).map_err(|e| e.to_string()),
+    }
+}

--- a/crates/aptos-fuzzer/src/mutator.rs
+++ b/crates/aptos-fuzzer/src/mutator.rs
@@ -9,6 +9,10 @@ use libafl::mutators::{MutationResult, Mutator};
 use libafl::state::HasRand;
 use libafl_bolts::rands::Rand;
 use libafl_bolts::Named;
+use aptos_move_binary_format::access::ModuleAccess;
+use aptos_move_core_types::language_storage::TypeTag;
+use aptos_move_core_types::value::MoveValue;
+use aptos_move_vm_runtime::ModuleStorage;
 
 use crate::input::{AptosFuzzerInput, Call};
 use crate::state::AptosFuzzerState;
@@ -24,16 +28,129 @@ impl AptosFuzzerMutator {
 
         let call_idx = (state.rand_mut().next() as usize) % input.calls.len();
         let func_call = &mut input.calls[call_idx];
+        // load parameter signature tokens for this function
+        let param_toks = Self::param_tokens_for_call(state, func_call);
         let mut mutated = false;
-        for arg in func_call.args.iter_mut() {
+        for (idx, arg) in func_call.args.iter_mut().enumerate() {
             if let CallArgument::Raw(ref mut bytes) = arg {
-                if Self::mutate_byte_vector(bytes, state) {
-                    mutated = true;
+                if let Some(ref toks) = param_toks {
+                    if let Some(tok) = toks.get(idx) {
+                        if Self::mutate_arg_bytes_for_token(bytes, tok, state) {
+                            mutated = true;
+                            continue;
+                        }
+                    }
                 }
+                if Self::mutate_byte_vector(bytes, state) { mutated = true; }
             }
         }
 
         mutated
+    }
+
+    fn mutate_arg_bytes_for_token(
+        bytes: &mut Vec<u8>,
+        tok: &aptos_move_binary_format::file_format::SignatureToken,
+        state: &mut AptosFuzzerState,
+    ) -> bool {
+        use aptos_move_binary_format::file_format::SignatureToken as ST;
+        match tok {
+            ST::Vector(inner) => {
+                // Allow free byte mutation only for vector<u8>
+                if matches!(**inner, ST::U8) {
+                    return Self::mutate_byte_vector(bytes, state);
+                }
+                // For vector<T> with T != u8, perform structured mutation with valid BCS
+                let choice = state.rand_mut().next() % 3;
+                let len = match choice { 0 => 0usize, 1 => 1usize, _ => 2usize };
+                let mut elems = Vec::with_capacity(len);
+                for _ in 0..len {
+                    if let Some(tag) = Self::token_to_typetag_primitive(inner) {
+                        // generate a small random element for primitive types
+                        let mv = Self::random_move_value_for_tag(&tag, state);
+                        if let Some(mv) = mv { elems.push(mv) } else { elems.push(MoveValue::U8(0)) }
+                    } else {
+                        elems.push(MoveValue::U8(0));
+                    }
+                }
+                let mv = MoveValue::Vector(elems);
+                if let Some(bcs) = mv.simple_serialize() { *bytes = bcs; return true; }
+                false
+            }
+            // For fixed-size primitives, clamp length to expected and fill random
+            ST::Bool | ST::U8 | ST::U16 | ST::U32 | ST::U64 | ST::U128 | ST::U256 | ST::Address => {
+                let tag = Self::token_to_typetag_primitive(tok).unwrap();
+                if let Some(expected) = Self::expected_fixed_len_bytes(&tag) {
+                    let mut v = vec![0u8; expected];
+                    for b in v.iter_mut() { *b = (state.rand_mut().next() & 0xFF) as u8; }
+                    *bytes = v;
+                    return true;
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    fn token_to_typetag_primitive(
+        tok: &aptos_move_binary_format::file_format::SignatureToken,
+    ) -> Option<TypeTag> {
+        use aptos_move_binary_format::file_format::SignatureToken as ST;
+        match tok {
+            ST::Bool => Some(TypeTag::Bool),
+            ST::U8 => Some(TypeTag::U8),
+            ST::U16 => Some(TypeTag::U16),
+            ST::U32 => Some(TypeTag::U32),
+            ST::U64 => Some(TypeTag::U64),
+            ST::U128 => Some(TypeTag::U128),
+            ST::U256 => Some(TypeTag::U256),
+            ST::Address => Some(TypeTag::Address),
+            ST::Vector(inner) => Self::token_to_typetag_primitive(inner).map(|t| TypeTag::Vector(Box::new(t))),
+            _ => None,
+        }
+    }
+
+    fn random_move_value_for_tag(tag: &TypeTag, state: &mut AptosFuzzerState) -> Option<MoveValue> {
+        match tag {
+            TypeTag::Bool => Some(MoveValue::Bool((state.rand_mut().next() & 1) != 0)),
+            TypeTag::U8 => Some(MoveValue::U8((state.rand_mut().next() & 0xFF) as u8)),
+            TypeTag::U16 => Some(MoveValue::U16((state.rand_mut().next() & 0xFFFF) as u16)),
+            TypeTag::U32 => Some(MoveValue::U32((state.rand_mut().next() & 0xFFFF_FFFF) as u32)),
+            TypeTag::U64 => Some(MoveValue::U64(state.rand_mut().next() as u64)),
+            TypeTag::U128 => Some(MoveValue::U128((state.rand_mut().next() as u128) << 64)),
+            TypeTag::U256 => Some(MoveValue::U256(0u128.into())),
+            TypeTag::Address => Some(MoveValue::Address(AccountAddress::random())),
+            _ => None,
+        }
+    }
+
+    fn expected_fixed_len_bytes(tag: &TypeTag) -> Option<usize> {
+        match tag {
+            TypeTag::Bool => Some(1),
+            TypeTag::U8 => Some(1),
+            TypeTag::U16 => Some(2),
+            TypeTag::U32 => Some(4),
+            TypeTag::U64 => Some(8),
+            TypeTag::U128 => Some(16),
+            TypeTag::U256 => Some(32),
+            TypeTag::Address => Some(32),
+            _ => None,
+        }
+    }
+
+    fn param_tokens_for_call(state: &AptosFuzzerState, call: &Call) -> Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> {
+        let cm = state
+            .aptos_state()
+            .unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name())
+            .ok()
+            .flatten()?;
+        for def in cm.function_defs() {
+            let h = cm.function_handle_at(def.function);
+            if cm.identifier_at(h.name) == call.function_name.as_ident_str() {
+                return Some(cm.signature_at(h.parameters).0.clone());
+            }
+        }
+        None
     }
 
     fn mutate_byte_vector(bytes: &mut Vec<u8>, state: &mut AptosFuzzerState) -> bool {

--- a/crates/aptos-fuzzer/src/mutator.rs
+++ b/crates/aptos-fuzzer/src/mutator.rs
@@ -4,13 +4,12 @@ use std::collections::HashSet;
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::ModuleId;
-use aptos_types::transaction::EntryFunction;
 use libafl::mutators::{MutationResult, Mutator};
 use libafl::state::HasRand;
 use libafl_bolts::rands::Rand;
 use libafl_bolts::Named;
 
-use crate::input::AptosFuzzerInput;
+use crate::input::{AptosFuzzerInput, FuncCall};
 use crate::state::AptosFuzzerState;
 
 #[derive(Default)]
@@ -23,63 +22,22 @@ impl AptosFuzzerMutator {
         }
         
         let call_idx = (state.rand_mut().next() as usize) % input.calls.len();
-        let entry_func = &mut input.calls[call_idx];
+        let func_call = &mut input.calls[call_idx];
         
-        let args = entry_func.args();
-        if args.is_empty() {
+        if func_call.bcs_args.is_empty() {
             return false;
         }
 
-        // Create new mutated arguments
-        let mut new_args = Vec::new();
         let mut mutated = false;
-
-        for arg_bytes in args.iter() {
-            let mut mutated_arg = arg_bytes.clone();
-            if Self::mutate_byte_vector(&mut mutated_arg, state) {
+        for arg_bytes in func_call.bcs_args.iter_mut() {
+            if Self::mutate_byte_vector(arg_bytes, state) {
                 mutated = true;
             }
-            new_args.push(mutated_arg);
-        }
-
-        if mutated {
-            // Reconstruct EntryFunction with mutated args
-            let (module, function, ty_args, _) = entry_func.clone().into_inner();
-            *entry_func = EntryFunction::new(module, function, ty_args, new_args);
         }
 
         mutated
     }
 
-    /// Mutate Script arguments using state's random source (pure random)
-    fn mutate_script_args(script: &mut Script, state: &mut AptosFuzzerState) -> bool {
-        let args = script.args();
-        if args.is_empty() {
-            return false;
-        }
-
-        // Create new mutated arguments
-        let mut new_args = Vec::new();
-        let mut mutated = false;
-
-        for arg in args.iter() {
-            let mut mutated_arg = arg.clone();
-            if Self::mutate_transaction_argument(&mut mutated_arg, state) {
-                mutated = true;
-            }
-            new_args.push(mutated_arg);
-        }
-
-        if mutated {
-            // Reconstruct Script with mutated args
-            let (code, ty_args, _) = script.clone().into_inner();
-            *script = Script::new(code, ty_args, new_args);
-        }
-
-        mutated
-    }
-
-    /// Mutate a byte vector using state's random source (pure random bytes)
     fn mutate_byte_vector(bytes: &mut Vec<u8>, state: &mut AptosFuzzerState) -> bool {
         let len = if bytes.is_empty() {
             // choose a small random length
@@ -108,13 +66,13 @@ impl AptosFuzzerMutator {
         let call_idx = (state.rand_mut().next() as usize) % chain.len();
         let call = &chain.calls[call_idx];
         
-        let entry_func = match Self::call_to_entry_function(call) {
-            Ok(ef) => ef,
+        let func_call = match Self::call_to_func_call(call) {
+            Ok(fc) => fc,
             Err(_) => return false,
         };
         
         let insert_pos = Self::find_insertion_position(&chain, &input.calls, call_idx);
-        input.calls.insert(insert_pos, entry_func);
+        input.calls.insert(insert_pos, func_call);
         
         true
     }
@@ -154,7 +112,7 @@ impl AptosFuzzerMutator {
         false
     }
     
-    fn call_to_entry_function(call: &crate::mir::Call) -> Result<EntryFunction, String> {
+    fn call_to_func_call(call: &crate::mir::Call) -> Result<FuncCall, String> {
         let addr_bytes = hex::decode(&call.module_addr)
             .map_err(|e| format!("Invalid module address: {}", e))?;
         if addr_bytes.len() != 32 {
@@ -172,10 +130,10 @@ impl AptosFuzzerMutator {
         let module_id = ModuleId::new(module_addr, module_name);
         let args = vec![vec![0u8; 8]; call.args.len()];
         
-        Ok(EntryFunction::new(module_id, function_name, vec![], args))
+        Ok(FuncCall::new(module_id, function_name, vec![], args))
     }
     
-    fn find_insertion_position(chain: &crate::mir::Chain, calls: &[EntryFunction], call_idx: usize) -> usize {
+    fn find_insertion_position(chain: &crate::mir::Chain, calls: &[FuncCall], call_idx: usize) -> usize {
         let call = &chain.calls[call_idx];
         
         let mut requires_structs = HashSet::new();
@@ -205,7 +163,7 @@ impl AptosFuzzerMutator {
     
     fn can_swap_safely(
         _chain: &crate::mir::Chain,
-        _calls: &[EntryFunction],
+        _calls: &[FuncCall],
         idx1: usize,
         idx2: usize,
     ) -> bool {

--- a/crates/aptos-fuzzer/src/mutator.rs
+++ b/crates/aptos-fuzzer/src/mutator.rs
@@ -1,6 +1,10 @@
 use std::borrow::Cow;
+use std::collections::HashSet;
 
-use aptos_types::transaction::{EntryFunction, Script, TransactionArgument, TransactionPayload};
+use aptos_move_core_types::account_address::AccountAddress;
+use aptos_move_core_types::identifier::Identifier;
+use aptos_move_core_types::language_storage::ModuleId;
+use aptos_types::transaction::EntryFunction;
 use libafl::mutators::{MutationResult, Mutator};
 use libafl::state::HasRand;
 use libafl_bolts::rands::Rand;
@@ -13,7 +17,14 @@ use crate::state::AptosFuzzerState;
 pub struct AptosFuzzerMutator {}
 
 impl AptosFuzzerMutator {
-    fn mutate_entry_function_args(entry_func: &mut EntryFunction, state: &mut AptosFuzzerState) -> bool {
+    fn mutate_call_args(input: &mut AptosFuzzerInput, state: &mut AptosFuzzerState) -> bool {
+        if input.calls.is_empty() {
+            return false;
+        }
+        
+        let call_idx = (state.rand_mut().next() as usize) % input.calls.len();
+        let entry_func = &mut input.calls[call_idx];
+        
         let args = entry_func.args();
         if args.is_empty() {
             return false;
@@ -83,80 +94,128 @@ impl AptosFuzzerMutator {
         }
         true
     }
-
-    /// Mutate a TransactionArgument using state's random source (pure random)
-    fn mutate_transaction_argument(arg: &mut TransactionArgument, state: &mut AptosFuzzerState) -> bool {
-        match arg {
-            TransactionArgument::U8(val) => {
-                *val = (state.rand_mut().next() & 0xFF) as u8;
-                true
-            }
-            TransactionArgument::U16(val) => {
-                *val = (state.rand_mut().next() % 65536) as u16;
-                true
-            }
-            TransactionArgument::U32(val) => {
-                *val = (state.rand_mut().next() & 0xFFFF_FFFF) as u32;
-                true
-            }
-            TransactionArgument::U64(val) => {
-                *val = state.rand_mut().next();
-                true
-            }
-            TransactionArgument::U128(val) => {
-                let hi = state.rand_mut().next() as u128;
-                let lo = state.rand_mut().next() as u128;
-                *val = (hi << 64) | lo;
-                true
-            }
-            TransactionArgument::U256(val) => {
-                let high_part = {
-                    let hi = state.rand_mut().next() as u128;
-                    let lo = state.rand_mut().next() as u128;
-                    (hi << 64) | lo
-                };
-                let low_part = {
-                    let hi = state.rand_mut().next() as u128;
-                    let lo = state.rand_mut().next() as u128;
-                    (hi << 64) | lo
-                };
-                let mut bytes = [0u8; 32];
-                bytes[0..16].copy_from_slice(&low_part.to_le_bytes());
-                bytes[16..32].copy_from_slice(&high_part.to_le_bytes());
-                *val = aptos_move_core_types::u256::U256::from_le_bytes(&bytes);
-                true
-            }
-            TransactionArgument::Bool(val) => {
-                *val = (state.rand_mut().next() & 1) == 0;
-                true
-            }
-            TransactionArgument::Address(_addr) => {
-                let mut addr_bytes = [0u8; 32];
-                for byte in addr_bytes.iter_mut() {
-                    *byte = (state.rand_mut().next() % 256) as u8;
+    
+    fn mutate_add_call_from_chain(state: &mut AptosFuzzerState, input: &mut AptosFuzzerInput) -> bool {
+        let chain = match state.chain() {
+            Some(c) => c.clone(),
+            None => return false,
+        };
+        
+        if chain.is_empty() {
+            return false;
+        }
+        
+        let call_idx = (state.rand_mut().next() as usize) % chain.len();
+        let call = &chain.calls[call_idx];
+        
+        let entry_func = match Self::call_to_entry_function(call) {
+            Ok(ef) => ef,
+            Err(_) => return false,
+        };
+        
+        let insert_pos = Self::find_insertion_position(&chain, &input.calls, call_idx);
+        input.calls.insert(insert_pos, entry_func);
+        
+        true
+    }
+    
+    fn mutate_shuffle_calls(state: &mut AptosFuzzerState, input: &mut AptosFuzzerInput) -> bool {
+        if input.calls.len() < 2 {
+            return false;
+        }
+        
+        let chain = match state.chain() {
+            Some(c) => c.clone(),
+            None => {
+                let idx1 = (state.rand_mut().next() as usize) % input.calls.len();
+                let idx2 = (state.rand_mut().next() as usize) % input.calls.len();
+                if idx1 != idx2 {
+                    input.calls.swap(idx1, idx2);
+                    return true;
                 }
-                *_addr = aptos_move_core_types::account_address::AccountAddress::try_from(addr_bytes.to_vec())
-                    .unwrap_or(*_addr);
-                true
+                return false;
             }
-            TransactionArgument::U8Vector(vec) => {
-                let len = (state.rand_mut().next() % 64) as usize;
-                vec.clear();
-                for _ in 0..len {
-                    vec.push((state.rand_mut().next() & 0xFF) as u8);
-                }
-                true
+        };
+        
+        for _ in 0..10 {
+            let idx1 = (state.rand_mut().next() as usize) % input.calls.len();
+            let idx2 = (state.rand_mut().next() as usize) % input.calls.len();
+            
+            if idx1 == idx2 {
+                continue;
             }
-            TransactionArgument::Serialized(bytes) => {
-                let len = (state.rand_mut().next() % 64) as usize;
-                bytes.clear();
-                bytes.resize(len, 0);
-                for b in bytes.iter_mut() {
-                    *b = (state.rand_mut().next() & 0xFF) as u8;
-                }
-                true
+            
+            if Self::can_swap_safely(&chain, &input.calls, idx1, idx2) {
+                input.calls.swap(idx1, idx2);
+                return true;
             }
         }
+        
+        false
+    }
+    
+    fn call_to_entry_function(call: &crate::mir::Call) -> Result<EntryFunction, String> {
+        let addr_bytes = hex::decode(&call.module_addr)
+            .map_err(|e| format!("Invalid module address: {}", e))?;
+        if addr_bytes.len() != 32 {
+            return Err(format!("Module address must be 32 bytes, got {}", addr_bytes.len()));
+        }
+        let mut addr_array = [0u8; 32];
+        addr_array.copy_from_slice(&addr_bytes);
+        let module_addr = AccountAddress::new(addr_array);
+        
+        let module_name = Identifier::new(call.module.as_str())
+            .map_err(|e| format!("Invalid module name: {}", e))?;
+        let function_name = Identifier::new(call.function.as_str())
+            .map_err(|e| format!("Invalid function name: {}", e))?;
+        
+        let module_id = ModuleId::new(module_addr, module_name);
+        let args = vec![vec![0u8; 8]; call.args.len()];
+        
+        Ok(EntryFunction::new(module_id, function_name, vec![], args))
+    }
+    
+    fn find_insertion_position(chain: &crate::mir::Chain, calls: &[EntryFunction], call_idx: usize) -> usize {
+        let call = &chain.calls[call_idx];
+        
+        let mut requires_structs = HashSet::new();
+        for fact in &call.requires {
+            if let crate::mir::Fact::Exists(res) = fact {
+                requires_structs.insert(&res.struct_name);
+            }
+        }
+        
+        if requires_structs.is_empty() {
+            return 0;
+        }
+        
+        let mut latest_creator_pos = 0;
+        
+        for (pos, _entry_func) in calls.iter().enumerate() {
+            for struct_name in &requires_structs {
+                let creators = chain.calls_creating_struct(struct_name);
+                if !creators.is_empty() {
+                    latest_creator_pos = pos + 1;
+                }
+            }
+        }
+        
+        latest_creator_pos.min(calls.len())
+    }
+    
+    fn can_swap_safely(
+        _chain: &crate::mir::Chain,
+        _calls: &[EntryFunction],
+        idx1: usize,
+        idx2: usize,
+    ) -> bool {
+        let (_earlier, later) = if idx1 < idx2 { (idx1, idx2) } else { (idx2, idx1) };
+        
+        if later - idx1.min(idx2) == 1 {
+            return true;
+        }
+        
+        true
     }
 }
 
@@ -166,11 +225,14 @@ impl Mutator<AptosFuzzerInput, AptosFuzzerState> for AptosFuzzerMutator {
         state: &mut AptosFuzzerState,
         input: &mut AptosFuzzerInput,
     ) -> Result<MutationResult, libafl::Error> {
-        let payload = input.payload_mut();
-        let mutated = match payload {
-            TransactionPayload::EntryFunction(entry_func) => Self::mutate_entry_function_args(entry_func, state),
-            TransactionPayload::Script(script) => Self::mutate_script_args(script, state),
-            _ => false, // Other payload types not supported for current mutator
+        let choice = state.rand_mut().next() % 100;
+        
+        let mutated = if choice < 60 {
+            Self::mutate_call_args(input, state)
+        } else if choice < 80 {
+            Self::mutate_add_call_from_chain(state, input)
+        } else {
+            Self::mutate_shuffle_calls(state, input)
         };
 
         if mutated {

--- a/crates/aptos-fuzzer/src/mutator.rs
+++ b/crates/aptos-fuzzer/src/mutator.rs
@@ -2,17 +2,16 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 
 use aptos_dynamic_transaction_composer::CallArgument;
+use aptos_move_binary_format::access::ModuleAccess;
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
-use aptos_move_core_types::language_storage::ModuleId;
+use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
+use aptos_move_core_types::value::MoveValue;
+use aptos_move_vm_runtime::ModuleStorage;
 use libafl::mutators::{MutationResult, Mutator};
 use libafl::state::HasRand;
 use libafl_bolts::rands::Rand;
 use libafl_bolts::Named;
-use aptos_move_binary_format::access::ModuleAccess;
-use aptos_move_core_types::language_storage::TypeTag;
-use aptos_move_core_types::value::MoveValue;
-use aptos_move_vm_runtime::ModuleStorage;
 
 use crate::input::{AptosFuzzerInput, Call};
 use crate::state::AptosFuzzerState;
@@ -41,7 +40,9 @@ impl AptosFuzzerMutator {
                         }
                     }
                 }
-                if Self::mutate_byte_vector(bytes, state) { mutated = true; }
+                if Self::mutate_byte_vector(bytes, state) {
+                    mutated = true;
+                }
             }
         }
 
@@ -62,19 +63,30 @@ impl AptosFuzzerMutator {
                 }
                 // For vector<T> with T != u8, perform structured mutation with valid BCS
                 let choice = state.rand_mut().next() % 3;
-                let len = match choice { 0 => 0usize, 1 => 1usize, _ => 2usize };
+                let len = match choice {
+                    0 => 0usize,
+                    1 => 1usize,
+                    _ => 2usize,
+                };
                 let mut elems = Vec::with_capacity(len);
                 for _ in 0..len {
                     if let Some(tag) = Self::token_to_typetag_primitive(inner) {
                         // generate a small random element for primitive types
                         let mv = Self::random_move_value_for_tag(&tag, state);
-                        if let Some(mv) = mv { elems.push(mv) } else { elems.push(MoveValue::U8(0)) }
+                        if let Some(mv) = mv {
+                            elems.push(mv)
+                        } else {
+                            elems.push(MoveValue::U8(0))
+                        }
                     } else {
                         elems.push(MoveValue::U8(0));
                     }
                 }
                 let mv = MoveValue::Vector(elems);
-                if let Some(bcs) = mv.simple_serialize() { *bytes = bcs; return true; }
+                if let Some(bcs) = mv.simple_serialize() {
+                    *bytes = bcs;
+                    return true;
+                }
                 false
             }
             // For fixed-size primitives, clamp length to expected and fill random
@@ -82,7 +94,9 @@ impl AptosFuzzerMutator {
                 let tag = Self::token_to_typetag_primitive(tok).unwrap();
                 if let Some(expected) = Self::expected_fixed_len_bytes(&tag) {
                     let mut v = vec![0u8; expected];
-                    for b in v.iter_mut() { *b = (state.rand_mut().next() & 0xFF) as u8; }
+                    for b in v.iter_mut() {
+                        *b = (state.rand_mut().next() & 0xFF) as u8;
+                    }
                     *bytes = v;
                     return true;
                 }
@@ -92,9 +106,7 @@ impl AptosFuzzerMutator {
         }
     }
 
-    fn token_to_typetag_primitive(
-        tok: &aptos_move_binary_format::file_format::SignatureToken,
-    ) -> Option<TypeTag> {
+    fn token_to_typetag_primitive(tok: &aptos_move_binary_format::file_format::SignatureToken) -> Option<TypeTag> {
         use aptos_move_binary_format::file_format::SignatureToken as ST;
         match tok {
             ST::Bool => Some(TypeTag::Bool),
@@ -138,7 +150,10 @@ impl AptosFuzzerMutator {
         }
     }
 
-    fn param_tokens_for_call(state: &AptosFuzzerState, call: &Call) -> Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> {
+    fn param_tokens_for_call(
+        state: &AptosFuzzerState,
+        call: &Call,
+    ) -> Option<Vec<aptos_move_binary_format::file_format::SignatureToken>> {
         let cm = state
             .aptos_state()
             .unmetered_get_deserialized_module(call.module_id.address(), call.module_id.name())

--- a/crates/aptos-fuzzer/src/mutator.rs
+++ b/crates/aptos-fuzzer/src/mutator.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 
+use aptos_dynamic_transaction_composer::CallArgument;
 use aptos_move_core_types::account_address::AccountAddress;
 use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::ModuleId;
@@ -9,7 +10,7 @@ use libafl::state::HasRand;
 use libafl_bolts::rands::Rand;
 use libafl_bolts::Named;
 
-use crate::input::{AptosFuzzerInput, FuncCall};
+use crate::input::{AptosFuzzerInput, Call};
 use crate::state::AptosFuzzerState;
 
 #[derive(Default)]
@@ -20,18 +21,15 @@ impl AptosFuzzerMutator {
         if input.calls.is_empty() {
             return false;
         }
-        
+
         let call_idx = (state.rand_mut().next() as usize) % input.calls.len();
         let func_call = &mut input.calls[call_idx];
-        
-        if func_call.bcs_args.is_empty() {
-            return false;
-        }
-
         let mut mutated = false;
-        for arg_bytes in func_call.bcs_args.iter_mut() {
-            if Self::mutate_byte_vector(arg_bytes, state) {
-                mutated = true;
+        for arg in func_call.args.iter_mut() {
+            if let CallArgument::Raw(ref mut bytes) = arg {
+                if Self::mutate_byte_vector(bytes, state) {
+                    mutated = true;
+                }
             }
         }
 
@@ -52,36 +50,36 @@ impl AptosFuzzerMutator {
         }
         true
     }
-    
+
     fn mutate_add_call_from_chain(state: &mut AptosFuzzerState, input: &mut AptosFuzzerInput) -> bool {
         let chain = match state.chain() {
             Some(c) => c.clone(),
             None => return false,
         };
-        
+
         if chain.is_empty() {
             return false;
         }
-        
+
         let call_idx = (state.rand_mut().next() as usize) % chain.len();
         let call = &chain.calls[call_idx];
-        
-        let func_call = match Self::call_to_func_call(call) {
+
+        let func_call = match Self::call_to_call(call) {
             Ok(fc) => fc,
             Err(_) => return false,
         };
-        
+
         let insert_pos = Self::find_insertion_position(&chain, &input.calls, call_idx);
         input.calls.insert(insert_pos, func_call);
-        
+
         true
     }
-    
+
     fn mutate_shuffle_calls(state: &mut AptosFuzzerState, input: &mut AptosFuzzerInput) -> bool {
         if input.calls.len() < 2 {
             return false;
         }
-        
+
         let chain = match state.chain() {
             Some(c) => c.clone(),
             None => {
@@ -94,61 +92,58 @@ impl AptosFuzzerMutator {
                 return false;
             }
         };
-        
+
         for _ in 0..10 {
             let idx1 = (state.rand_mut().next() as usize) % input.calls.len();
             let idx2 = (state.rand_mut().next() as usize) % input.calls.len();
-            
+
             if idx1 == idx2 {
                 continue;
             }
-            
+
             if Self::can_swap_safely(&chain, &input.calls, idx1, idx2) {
                 input.calls.swap(idx1, idx2);
                 return true;
             }
         }
-        
+
         false
     }
-    
-    fn call_to_func_call(call: &crate::mir::Call) -> Result<FuncCall, String> {
-        let addr_bytes = hex::decode(&call.module_addr)
-            .map_err(|e| format!("Invalid module address: {}", e))?;
+
+    fn call_to_call(call: &crate::mir::Call) -> Result<Call, String> {
+        let addr_bytes = hex::decode(&call.module_addr).map_err(|e| format!("Invalid module address: {}", e))?;
         if addr_bytes.len() != 32 {
             return Err(format!("Module address must be 32 bytes, got {}", addr_bytes.len()));
         }
         let mut addr_array = [0u8; 32];
         addr_array.copy_from_slice(&addr_bytes);
         let module_addr = AccountAddress::new(addr_array);
-        
-        let module_name = Identifier::new(call.module.as_str())
-            .map_err(|e| format!("Invalid module name: {}", e))?;
-        let function_name = Identifier::new(call.function.as_str())
-            .map_err(|e| format!("Invalid function name: {}", e))?;
-        
+
+        let module_name = Identifier::new(call.module.as_str()).map_err(|e| format!("Invalid module name: {}", e))?;
+        let function_name =
+            Identifier::new(call.function.as_str()).map_err(|e| format!("Invalid function name: {}", e))?;
+
         let module_id = ModuleId::new(module_addr, module_name);
-        let args = vec![vec![0u8; 8]; call.args.len()];
-        
-        Ok(FuncCall::new(module_id, function_name, vec![], args))
+        let args = vec![CallArgument::Raw(vec![0u8; 8]); call.args.len()];
+        Ok(Call::new(module_id, function_name, vec![], args))
     }
-    
-    fn find_insertion_position(chain: &crate::mir::Chain, calls: &[FuncCall], call_idx: usize) -> usize {
+
+    fn find_insertion_position(chain: &crate::mir::Chain, calls: &[Call], call_idx: usize) -> usize {
         let call = &chain.calls[call_idx];
-        
+
         let mut requires_structs = HashSet::new();
         for fact in &call.requires {
             if let crate::mir::Fact::Exists(res) = fact {
                 requires_structs.insert(&res.struct_name);
             }
         }
-        
+
         if requires_structs.is_empty() {
             return 0;
         }
-        
+
         let mut latest_creator_pos = 0;
-        
+
         for (pos, _entry_func) in calls.iter().enumerate() {
             for struct_name in &requires_structs {
                 let creators = chain.calls_creating_struct(struct_name);
@@ -157,22 +152,17 @@ impl AptosFuzzerMutator {
                 }
             }
         }
-        
+
         latest_creator_pos.min(calls.len())
     }
-    
-    fn can_swap_safely(
-        _chain: &crate::mir::Chain,
-        _calls: &[FuncCall],
-        idx1: usize,
-        idx2: usize,
-    ) -> bool {
+
+    fn can_swap_safely(_chain: &crate::mir::Chain, _calls: &[Call], idx1: usize, idx2: usize) -> bool {
         let (_earlier, later) = if idx1 < idx2 { (idx1, idx2) } else { (idx2, idx1) };
-        
+
         if later - idx1.min(idx2) == 1 {
             return true;
         }
-        
+
         true
     }
 }
@@ -184,7 +174,7 @@ impl Mutator<AptosFuzzerInput, AptosFuzzerState> for AptosFuzzerMutator {
         input: &mut AptosFuzzerInput,
     ) -> Result<MutationResult, libafl::Error> {
         let choice = state.rand_mut().next() % 100;
-        
+
         let mutated = if choice < 60 {
             Self::mutate_call_args(input, state)
         } else if choice < 80 {

--- a/crates/aptos-fuzzer/src/state.rs
+++ b/crates/aptos-fuzzer/src/state.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use aptos_move_binary_format::CompiledModule;
-use aptos_vm::aptos_vm::FUZZER_SENDER;
 use aptos_move_core_types::language_storage::ModuleId;
 use libafl::corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, InMemoryCorpus, Testcase};
 use libafl::stages::StageId;
@@ -116,19 +115,26 @@ impl AptosFuzzerState {
         // Load MIR Chain and convert to inputs
         if let Some(mir_path) = mir_path {
             match Self::load_chain_from_mir(&mir_path) {
-                Ok(chain) => {
-                    println!("Loaded MIR chain with {} calls", chain.len());
+                Ok(mut chain) => {
+                    let call_count = chain.len();
+                    println!("Loaded MIR chain with {} calls", call_count);
                     
-                    match chain.to_transaction_payload() {
-                        Ok(payloads) => {
-                            for payload in payloads {
-                                let input = AptosFuzzerInput::new(payload);
+                    chain.sort_by_dependencies();
+                    
+                    match chain.to_entry_functions() {
+                        Ok(functions) => {
+                            // Seed corpus with each MIR call as a single-call input
+                            for (idx, func) in functions.into_iter().enumerate() {
+                                let input = AptosFuzzerInput::new(func);
                                 let _ = state.corpus.add(Testcase::new(input));
+                                if (idx + 1) % 10 == 0 || idx + 1 == call_count {
+                                    println!("  Added {}/{} individual calls to corpus", idx + 1, call_count);
+                                }
                             }
-                            println!("Added {} inputs to corpus from MIR", state.corpus.count());
+                            println!("Successfully seeded corpus with {} single-call inputs", state.corpus.count());
                         }
                         Err(e) => {
-                            eprintln!("Failed to convert MIR chain to payloads: {}", e);
+                            eprintln!("Failed to convert MIR chain to entry functions: {}", e);
                         }
                     }
                     state.chain = Some(chain);

--- a/crates/aptos-fuzzer/src/state.rs
+++ b/crates/aptos-fuzzer/src/state.rs
@@ -5,12 +5,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use aptos_move_binary_format::CompiledModule;
-use aptos_move_core_types::account_address::AccountAddress;
-use aptos_move_core_types::identifier::Identifier;
-use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
-use aptos_move_core_types::u256::U256;
-use aptos_types::transaction::{EntryABI, EntryFunction as AptosEntryFunction, EntryFunctionABI, TransactionPayload};
 use aptos_vm::aptos_vm::FUZZER_SENDER;
+use aptos_move_core_types::language_storage::ModuleId;
 use libafl::corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, InMemoryCorpus, Testcase};
 use libafl::stages::StageId;
 use libafl::state::{
@@ -85,47 +81,6 @@ struct ExecutionPathRecord {
 }
 
 impl AptosFuzzerState {
-    pub fn new(abi_path: Option<PathBuf>, module_path: Option<PathBuf>) -> Self {
-        let entry_abis = Self::load_abis_from_path(abi_path);
-        let module_bytes = Self::load_module_from_path(module_path);
-        let mut state = Self {
-            // TODO: replace me with actual aptos state
-            aptos_state: AptosCustomState::new_default(),
-            rand: StdRand::new(),
-            executions: 0,
-            start_time: Duration::from_secs(0),
-            imported: 0,
-            corpus: InMemoryCorpus::new(),
-            solutions: InMemoryCorpus::new(),
-            current_execution_path: None,
-            current_execution_path_id: None,
-            execution_paths_by_input: HashMap::new(),
-            seen_execution_paths: HashSet::new(),
-            abort_code_paths: HashSet::new(),
-            shift_overflow_paths: HashSet::new(),
-            metadata: SerdeAnyMap::new(),
-            named_metadata: NamedSerdeAnyMap::new(),
-            last_found_time: Duration::from_secs(0),
-            last_report_time: None,
-            corpus_id: None,
-            stop_requested: false,
-            stage_stack: StageStack::default(),
-            cumulative_coverage: vec![0u8; MAP_SIZE],
-            chain: None,
-        };
-
-        if let Some((module_id, code)) = module_bytes {
-            state.aptos_state.deploy_module_bytes(module_id, code);
-        }
-
-        for payload in Self::padding_abis(entry_abis) {
-            let input = AptosFuzzerInput::new(payload);
-            let _ = state.corpus.add(Testcase::new(input));
-        }
-
-        state
-    }
-
     /// Load Chain from MIR JSON file and populate corpus
     pub fn load_from_mir(mir_path: Option<PathBuf>, module_path: Option<PathBuf>) -> Self {
         let module_bytes = Self::load_module_from_path(module_path.clone());
@@ -476,138 +431,6 @@ impl HasStartTime for AptosFuzzerState {
 }
 
 impl AptosFuzzerState {
-    fn load_abis_from_path(path: Option<PathBuf>) -> Vec<EntryFunctionABI> {
-        let Some(path) = path else {
-            return Vec::new();
-        };
-
-        let mut paths = Vec::new();
-        let mut abis = Vec::new();
-        Self::collect_abis(path.as_path(), &mut paths, &mut abis);
-        abis
-    }
-
-    fn collect_abis(path: &Path, paths: &mut Vec<PathBuf>, abis: &mut Vec<EntryFunctionABI>) {
-        if path.is_dir() {
-            let read_dir = match fs::read_dir(path) {
-                Ok(rd) => rd,
-                Err(_) => return,
-            };
-            for entry in read_dir {
-                match entry {
-                    Ok(dir_entry) => Self::collect_abis(&dir_entry.path(), paths, abis),
-                    Err(err) => eprintln!("[aptos-fuzzer] failed to read entry in {}: {err}", path.display()),
-                }
-            }
-            return;
-        }
-
-        if path.extension().map(|ext| ext != "abi").unwrap_or(true) {
-            return;
-        }
-
-        let bytes = match fs::read(path) {
-            Ok(bytes) => bytes,
-            Err(err) => {
-                eprintln!("[aptos-fuzzer] failed to read ABI file {}: {err}", path.display());
-                return;
-            }
-        };
-        // Try to decode as EntryABI first (new format from aptos move compile)
-        match bcs::from_bytes::<EntryABI>(&bytes) {
-            Ok(entry_abi) => {
-                if let EntryABI::EntryFunction(abi) = entry_abi {
-                    paths.push(path.to_path_buf());
-                    abis.push(abi);
-                }
-            }
-            Err(_) => {
-                // Fallback: try to decode as EntryFunctionABI directly (legacy format)
-                if let Ok(abi) = bcs::from_bytes::<EntryFunctionABI>(&bytes) {
-                    paths.push(path.to_path_buf());
-                    abis.push(abi);
-                }
-            }
-        }
-    }
-
-    fn padding_abis(abis: Vec<EntryFunctionABI>) -> Vec<TransactionPayload> {
-        let mut payloads = Vec::new();
-
-        for abi in abis {
-            if !abi.ty_args().is_empty() {
-                continue;
-            }
-
-            let identifier = match Identifier::new(abi.name()) {
-                Ok(id) => id,
-                Err(_) => continue,
-            };
-
-            let mut arg_bytes = Vec::new();
-            let mut unsupported = false;
-
-            for arg in abi.args() {
-                match Self::default_arg_bytes(arg.type_tag()) {
-                    Some(bytes) => arg_bytes.push(bytes),
-                    None => {
-                        unsupported = true;
-                        eprintln!(
-                            "[aptos-fuzzer] skipping {}::{}: unsupported argument type {:?}",
-                            abi.module_name(),
-                            abi.name(),
-                            arg.type_tag()
-                        );
-                        break;
-                    }
-                }
-            }
-
-            if unsupported {
-                continue;
-            }
-
-            while arg_bytes.len() < abi.args().len() {
-                // Fallback to empty vector<u8> if some type was not covered
-                if let Ok(bytes) = bcs::to_bytes::<Vec<u8>>(&Vec::new()) {
-                    arg_bytes.push(bytes);
-                } else {
-                    break;
-                }
-            }
-
-            let entry = AptosEntryFunction::new(abi.module_name().clone(), identifier, Vec::new(), arg_bytes);
-            payloads.push(TransactionPayload::EntryFunction(entry));
-        }
-
-        payloads
-    }
-
-    fn default_arg_bytes(type_tag: &TypeTag) -> Option<Vec<u8>> {
-        match type_tag {
-            TypeTag::Bool => bcs::to_bytes(&false).ok(),
-            TypeTag::U8 => bcs::to_bytes(&0u8).ok(),
-            TypeTag::U16 => bcs::to_bytes(&0u16).ok(),
-            TypeTag::U32 => bcs::to_bytes(&0u32).ok(),
-            TypeTag::U64 => bcs::to_bytes(&0u64).ok(),
-            TypeTag::U128 => bcs::to_bytes(&0u128).ok(),
-            TypeTag::U256 => bcs::to_bytes(&U256::from(0u8)).ok(),
-            TypeTag::Address => bcs::to_bytes(&FUZZER_SENDER).ok(),
-            TypeTag::Vector(inner) => match &**inner {
-                TypeTag::Bool => bcs::to_bytes::<Vec<bool>>(&Vec::new()).ok(),
-                TypeTag::U8 => bcs::to_bytes::<Vec<u8>>(&Vec::new()).ok(),
-                TypeTag::U16 => bcs::to_bytes::<Vec<u16>>(&Vec::new()).ok(),
-                TypeTag::U32 => bcs::to_bytes::<Vec<u32>>(&Vec::new()).ok(),
-                TypeTag::U64 => bcs::to_bytes::<Vec<u64>>(&Vec::new()).ok(),
-                TypeTag::U128 => bcs::to_bytes::<Vec<u128>>(&Vec::new()).ok(),
-                TypeTag::U256 => bcs::to_bytes::<Vec<U256>>(&Vec::new()).ok(),
-                TypeTag::Address => bcs::to_bytes::<Vec<AccountAddress>>(&Vec::new()).ok(),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
     fn load_module_from_path(path: Option<PathBuf>) -> Option<(ModuleId, Vec<u8>)> {
         let path = path?;
         let bytes = match fs::read(&path) {

--- a/crates/aptos-fuzzer/src/state.rs
+++ b/crates/aptos-fuzzer/src/state.rs
@@ -121,11 +121,11 @@ impl AptosFuzzerState {
                     
                     chain.sort_by_dependencies();
                     
-                    match chain.to_entry_functions() {
-                        Ok(functions) => {
+                    match chain.to_func_calls() {
+                        Ok(func_calls) => {
                             // Seed corpus with each MIR call as a single-call input
-                            for (idx, func) in functions.into_iter().enumerate() {
-                                let input = AptosFuzzerInput::new(func);
+                            for (idx, func_call) in func_calls.into_iter().enumerate() {
+                                let input = AptosFuzzerInput::new(func_call);
                                 let _ = state.corpus.add(Testcase::new(input));
                                 if (idx + 1) % 10 == 0 || idx + 1 == call_count {
                                     println!("  Added {}/{} individual calls to corpus", idx + 1, call_count);
@@ -134,7 +134,7 @@ impl AptosFuzzerState {
                             println!("Successfully seeded corpus with {} single-call inputs", state.corpus.count());
                         }
                         Err(e) => {
-                            eprintln!("Failed to convert MIR chain to entry functions: {}", e);
+                            eprintln!("Failed to convert MIR chain to func calls: {}", e);
                         }
                     }
                     state.chain = Some(chain);

--- a/crates/aptos-fuzzer/src/state.rs
+++ b/crates/aptos-fuzzer/src/state.rs
@@ -10,6 +10,7 @@ use aptos_move_core_types::identifier::Identifier;
 use aptos_move_core_types::language_storage::{ModuleId, TypeTag};
 use aptos_move_core_types::u256::U256;
 use aptos_types::transaction::{EntryABI, EntryFunction as AptosEntryFunction, EntryFunctionABI, TransactionPayload};
+use aptos_vm::aptos_vm::FUZZER_SENDER;
 use libafl::corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, InMemoryCorpus, Testcase};
 use libafl::stages::StageId;
 use libafl::state::{
@@ -22,6 +23,7 @@ use libafl_bolts::serdeany::{NamedSerdeAnyMap, SerdeAnyMap};
 
 use crate::executor::aptos_custom_state::AptosCustomState;
 use crate::input::AptosFuzzerInput;
+use crate::mir::Chain;
 
 // AFL-style map size constant
 pub const MAP_SIZE: usize = 1 << 16;
@@ -72,6 +74,8 @@ pub struct AptosFuzzerState {
     pub abort_code_paths: HashSet<u64>,
     /// Execution path IDs that triggered shift overflow objectives
     pub shift_overflow_paths: HashSet<u64>,
+    /// MIR Chain loaded from file
+    chain: Option<Chain>,
 }
 
 #[derive(Clone)]
@@ -107,6 +111,7 @@ impl AptosFuzzerState {
             stop_requested: false,
             stage_stack: StageStack::default(),
             cumulative_coverage: vec![0u8; MAP_SIZE],
+            chain: None,
         };
 
         if let Some((module_id, code)) = module_bytes {
@@ -121,9 +126,76 @@ impl AptosFuzzerState {
         state
     }
 
-    /// Drain current corpus entries into a vector of inputs and clear the
-    /// corpus. Useful to re-insert seeds via fuzzer.add_input so
-    /// events/feedback are fired.
+    /// Load Chain from MIR JSON file and populate corpus
+    pub fn load_from_mir(mir_path: Option<PathBuf>, module_path: Option<PathBuf>) -> Self {
+        let module_bytes = Self::load_module_from_path(module_path.clone());
+        let mut state = Self {
+            aptos_state: AptosCustomState::new_default(),
+            rand: StdRand::new(),
+            executions: 0,
+            start_time: Duration::from_secs(0),
+            imported: 0,
+            corpus: InMemoryCorpus::new(),
+            solutions: InMemoryCorpus::new(),
+            current_execution_path: None,
+            current_execution_path_id: None,
+            execution_paths_by_input: HashMap::new(),
+            seen_execution_paths: HashSet::new(),
+            abort_code_paths: HashSet::new(),
+            shift_overflow_paths: HashSet::new(),
+            metadata: SerdeAnyMap::new(),
+            named_metadata: NamedSerdeAnyMap::new(),
+            last_found_time: Duration::from_secs(0),
+            last_report_time: None,
+            corpus_id: None,
+            stop_requested: false,
+            stage_stack: StageStack::default(),
+            cumulative_coverage: vec![0u8; MAP_SIZE],
+            chain: None,
+        };
+
+        if let Some((module_id, code)) = module_bytes {
+            state.aptos_state.deploy_module_bytes(module_id, code);
+        }
+
+        // Load MIR Chain and convert to inputs
+        if let Some(mir_path) = mir_path {
+            match Self::load_chain_from_mir(&mir_path) {
+                Ok(chain) => {
+                    println!("Loaded MIR chain with {} calls", chain.len());
+                    
+                    match chain.to_transaction_payload() {
+                        Ok(payloads) => {
+                            for payload in payloads {
+                                let input = AptosFuzzerInput::new(payload);
+                                let _ = state.corpus.add(Testcase::new(input));
+                            }
+                            println!("Added {} inputs to corpus from MIR", state.corpus.count());
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to convert MIR chain to payloads: {}", e);
+                        }
+                    }
+                    state.chain = Some(chain);
+                }
+                Err(e) => {
+                    eprintln!("Failed to load MIR from {:?}: {}", mir_path, e);
+                }
+            }
+        }
+
+        state
+    }
+
+    fn load_chain_from_mir(path: &Path) -> Result<crate::mir::Chain, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read MIR file: {}", e))?;
+        let chain: crate::mir::Chain = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse MIR JSON: {}", e))?;
+        Ok(chain)
+    }
+
+    /// Drain corpus entries for re-insertion via fuzzer.add_input
     pub fn take_initial_inputs(&mut self) -> Vec<AptosFuzzerInput> {
         let ids: Vec<_> = self.corpus().ids().collect();
         let mut inputs = Vec::with_capacity(ids.len());
@@ -153,6 +225,22 @@ impl AptosFuzzerState {
 
     pub fn cumulative_coverage_mut(&mut self) -> &mut [u8] {
         &mut self.cumulative_coverage
+    }
+
+    pub fn chain(&self) -> Option<&Chain> {
+        self.chain.as_ref()
+    }
+
+    pub fn chain_mut(&mut self) -> Option<&mut Chain> {
+        self.chain.as_mut()
+    }
+
+    pub fn set_chain(&mut self, chain: Chain) {
+        self.chain = Some(chain);
+    }
+
+    pub fn take_chain(&mut self) -> Option<Chain> {
+        self.chain.take()
     }
 
     pub fn take_solutions(&self) -> Vec<AptosFuzzerInput> {
@@ -504,7 +592,7 @@ impl AptosFuzzerState {
             TypeTag::U64 => bcs::to_bytes(&0u64).ok(),
             TypeTag::U128 => bcs::to_bytes(&0u128).ok(),
             TypeTag::U256 => bcs::to_bytes(&U256::from(0u8)).ok(),
-            TypeTag::Address => bcs::to_bytes(&AccountAddress::ZERO).ok(),
+            TypeTag::Address => bcs::to_bytes(&FUZZER_SENDER).ok(),
             TypeTag::Vector(inner) => match &**inner {
                 TypeTag::Bool => bcs::to_bytes::<Vec<bool>>(&Vec::new()).ok(),
                 TypeTag::U8 => bcs::to_bytes::<Vec<u8>>(&Vec::new()).ok(),

--- a/crates/aptos-fuzzer/src/state.rs
+++ b/crates/aptos-fuzzer/src/state.rs
@@ -118,10 +118,10 @@ impl AptosFuzzerState {
                 Ok(mut chain) => {
                     let call_count = chain.len();
                     println!("Loaded MIR chain with {} calls", call_count);
-                    
+
                     chain.sort_by_dependencies();
-                    
-                    match chain.to_func_calls() {
+
+                    match chain.to_calls() {
                         Ok(func_calls) => {
                             // Seed corpus with each MIR call as a single-call input
                             for (idx, func_call) in func_calls.into_iter().enumerate() {
@@ -131,7 +131,10 @@ impl AptosFuzzerState {
                                     println!("  Added {}/{} individual calls to corpus", idx + 1, call_count);
                                 }
                             }
-                            println!("Successfully seeded corpus with {} single-call inputs", state.corpus.count());
+                            println!(
+                                "Successfully seeded corpus with {} single-call inputs",
+                                state.corpus.count()
+                            );
                         }
                         Err(e) => {
                             eprintln!("Failed to convert MIR chain to func calls: {}", e);
@@ -149,10 +152,9 @@ impl AptosFuzzerState {
     }
 
     fn load_chain_from_mir(path: &Path) -> Result<crate::mir::Chain, String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read MIR file: {}", e))?;
-        let chain: crate::mir::Chain = serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse MIR JSON: {}", e))?;
+        let content = fs::read_to_string(path).map_err(|e| format!("Failed to read MIR file: {}", e))?;
+        let chain: crate::mir::Chain =
+            serde_json::from_str(&content).map_err(|e| format!("Failed to parse MIR JSON: {}", e))?;
         Ok(chain)
     }
 

--- a/scripts/setup_aptos.sh
+++ b/scripts/setup_aptos.sh
@@ -7,20 +7,20 @@ echo "[*] Aptos Move Compilation and Fuzzing Script"
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Parse command line arguments
-CONTRACT_NAME="aptos-demo"
+CONTRACT_NAME="fuzzing-demo"
 TIMEOUT_DURATION=20
 
 usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
-    echo "  -c, --contract NAME    Contract name to fuzz (default: aptos-demo)"
+    echo "  -c, --contract NAME    Contract name to fuzz (default: fuzzing-demo)"
     echo "                         Available: aptos-demo, fuzzing-demo"
     echo "  -t, --timeout SECONDS  Timeout duration for fuzzing (default: 20)"
     echo "  -h, --help             Display this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                                    # Use default aptos-demo"
-    echo "  $0 -c fuzzing-demo                    # Fuzz the fuzzing-demo contract"
+    echo "  $0                                    # Use default fuzzing-demo"
+    echo "  $0 -c aptos-demo                      # Fuzz the aptos-demo contract"
     echo "  $0 -c fuzzing-demo -t 60              # Fuzz for 60 seconds"
     exit 1
 }
@@ -116,15 +116,15 @@ fi
 
 MODULE_PATH="$MODULE_FILE"
 
-# Find the ABI directory
-ABI_PATH=$(find "$BUILD_DIR" -type d -name "abis" -not -path "*/dependencies/*" | head -n 1)
-if [[ -z "$ABI_PATH" ]]; then
-    echo "[-] Error: No ABI directory found in $BUILD_DIR"
+# Find the MIR JSON file
+MIR_PATH="$CONTRACT_DIR/mir.json"
+if [[ ! -f "$MIR_PATH" ]]; then
+    echo "[-] Error: MIR file not found at: $MIR_PATH"
     exit 1
 fi
 
 echo "[*] Module path: $MODULE_PATH"
-echo "[*] ABI path: $ABI_PATH"
+echo "[*] MIR path: $MIR_PATH"
 
 # Verify the paths exist
 if [[ ! -f "$MODULE_PATH" ]]; then
@@ -132,19 +132,14 @@ if [[ ! -f "$MODULE_PATH" ]]; then
     exit 1
 fi
 
-if [[ ! -d "$ABI_PATH" ]]; then
-    echo "[-] Error: ABI directory not found at: $ABI_PATH"
-    exit 1
-fi
-
 echo "[+] Step 4: Running libafl-aptos fuzzer..."
 cd "$PROJECT_ROOT"
 
 echo "[*] Running command:"
-echo "[*] $LIBAFL_APTOS_BIN --module-path \"$MODULE_PATH\" --abi-path \"$ABI_PATH\" --timeout $TIMEOUT_DURATION"
+echo "[*] $LIBAFL_APTOS_BIN --mir-path \"$MIR_PATH\" --module-path \"$MODULE_PATH\" --timeout $TIMEOUT_DURATION"
 echo ""
 
 # Run the fuzzer with built-in timeout support
-"$LIBAFL_APTOS_BIN" --module-path "$MODULE_PATH" --abi-path "$ABI_PATH" --timeout "$TIMEOUT_DURATION"
+"$LIBAFL_APTOS_BIN" --mir-path "$MIR_PATH" --module-path "$MODULE_PATH" --timeout "$TIMEOUT_DURATION"
 
 echo "[+] Fuzzing completed"

--- a/scripts/setup_aptos.sh
+++ b/scripts/setup_aptos.sh
@@ -98,7 +98,7 @@ if [[ ! -d "build" ]]; then
     exit 1
 fi
 
-echo "[+] Step 3: Detecting artifact paths..."
+echo "[+] Step 3: Locating module bytecode and MIR file..."
 
 # Detect module name from build artifacts
 BUILD_DIR="$CONTRACT_DIR/build"


### PR DESCRIPTION
- optimize PC computation; fix Vec corpus/mutation bug;
- deserialize and persist MIR artifacts;
- switch to sequence-based FuncCall composition;
- wire script invocation into execution path;
- correct padding and string formatting;